### PR TITLE
Dev

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -62,6 +62,17 @@ say why here and then delete the entry.
   title, this is why the kgrapher once refused to assemble: it needs at least
   one system to say which cloud it is in.
 
+- **`orchestrator` serves `squests` but never registers it.** `serving`
+  dispatches the path and `orchestrateMultiple` answers it, and no
+  `components.Service` declares it, so it is absent from the registry, from the
+  graph and from every AAS built out of them. A consumer can only find it by
+  reading the Go.
+
+- **The Asset Interfaces Description has not been read by AAS tooling.** It is
+  built against the published IDTA 02017-1-0 template and unit-tested against
+  it, and nothing has yet loaded it into the AASX Package Explorer or FA³ST to
+  confirm the shape is accepted rather than merely plausible.
+
 ## Not yet run on hardware
 
 The mission type, `ServicePointList_v1`, the cervice lock, the client transport

--- a/TODO.md
+++ b/TODO.md
@@ -73,18 +73,21 @@ say why here and then delete the entry.
   it, and nothing has yet loaded it into the AASX Package Explorer or FA³ST to
   confirm the shape is accepted rather than merely plausible.
 
-- **Enabling authorization has never been tried on a cloud.** The bootstrap
-  exemption makes it possible — core-mission services are served without a token,
-  so discovery and registration no longer deadlock — but nothing has run that
-  way. Two things to watch when it is first switched on. Deregistration is
-  exempt only because `unregister` is core-mission; `ActionForMethod` maps DELETE
-  to the empty string by design, so if that service ever stopped being core, no
-  token could authorize it. And filtering at the orchestrator still applies to
-  core services, so `painter`, `kgrapher` and `modeler` will attempt an
-  orchestration for `syslist` on every walk that the authorizer refuses for want
-  of a rule — harmless, since `SystemList` then sends the request without a token
-  and the registrar accepts it, but it is traffic and possibly log noise. A rule
-  granting those three `read` on mission `core` would settle it.
+- **`painter`, `kgrapher` and `modeler` still reach the orchestrator over http.**
+  Their `syslist` reads work — it is core-mission and served without a token —
+  but every quest is refused with an empty subject and logged, so the
+  orchestrator and authorizer logs fill with refusals that are not denials. One
+  line each, the same change the thermostat needed.
+- **ds18b20's asset name reverted to the template's `sensor_Id`.** The 1-wire ID
+  is still right in the trait; it is the asset that lost it, so the registry,
+  the knowledge graph and any AAS now identify the sensor by a placeholder.
+  Worth checking whether its `FunctionalLocation` survived too: without it the
+  pairing rule still passes — an asset with no value satisfies the constraint —
+  so the kitchen-must-not-drive-the-bathroom property is not being exercised.
+- **Authorization has not been refused in anger.** Every denial so far has been
+  a misconfiguration. Nothing has yet tested a token expiring under load, a
+  second consumer competing for one provider, or a policy edit taking effect
+  while a control loop runs.
 
 ## Not yet run on hardware
 

--- a/TODO.md
+++ b/TODO.md
@@ -73,16 +73,18 @@ say why here and then delete the entry.
   it, and nothing has yet loaded it into the AASX Package Explorer or FA³ST to
   confirm the shape is accepted rather than merely plausible.
 
-- **The service registrar cannot be put behind the authorizer as things stand.**
-  Two independent reasons, both found while writing AlphaCloud's policy file.
-  First, `RegisterServices` sends a bare POST and `unregisterService` a bare
-  DELETE — neither carries a token, and neither could obtain one, because a
-  token comes from orchestration and orchestration needs the registry. Second,
-  `ActionForMethod` maps DELETE to the empty string by design, so no token claim
-  can ever match a deregistration. Until both are answered, `esr` must stay out
-  of the core-system list of anything that would enforce against it, and the
-  aggregation systems reading `syslist` need no policy. Enable enforcement on
-  leaf providers — `ds18b20`, `parallax` — first.
+- **Enabling authorization has never been tried on a cloud.** The bootstrap
+  exemption makes it possible — core-mission services are served without a token,
+  so discovery and registration no longer deadlock — but nothing has run that
+  way. Two things to watch when it is first switched on. Deregistration is
+  exempt only because `unregister` is core-mission; `ActionForMethod` maps DELETE
+  to the empty string by design, so if that service ever stopped being core, no
+  token could authorize it. And filtering at the orchestrator still applies to
+  core services, so `painter`, `kgrapher` and `modeler` will attempt an
+  orchestration for `syslist` on every walk that the authorizer refuses for want
+  of a rule — harmless, since `SystemList` then sends the request without a token
+  and the registrar accepts it, but it is traffic and possibly log noise. A rule
+  granting those three `read` on mission `core` would settle it.
 
 ## Not yet run on hardware
 

--- a/TODO.md
+++ b/TODO.md
@@ -73,21 +73,24 @@ say why here and then delete the entry.
   it, and nothing has yet loaded it into the AASX Package Explorer or FA³ST to
   confirm the shape is accepted rather than merely plausible.
 
-- **`painter`, `kgrapher` and `modeler` still reach the orchestrator over http.**
-  Their `syslist` reads work — it is core-mission and served without a token —
-  but every quest is refused with an empty subject and logged, so the
-  orchestrator and authorizer logs fill with refusals that are not denials. One
-  line each, the same change the thermostat needed.
-- **ds18b20's asset name reverted to the template's `sensor_Id`.** The 1-wire ID
-  is still right in the trait; it is the asset that lost it, so the registry,
-  the knowledge graph and any AAS now identify the sensor by a placeholder.
-  Worth checking whether its `FunctionalLocation` survived too: without it the
-  pairing rule still passes — an asset with no value satisfies the constraint —
-  so the kitchen-must-not-drive-the-bathroom property is not being exercised.
-- **Authorization has not been refused in anger.** Every denial so far has been
-  a misconfiguration. Nothing has yet tested a token expiring under load, a
-  second consumer competing for one provider, or a policy edit taking effect
-  while a control loop runs.
+- **A system that loses its `systemconfig.json` silently stops enforcing.**
+  Found on AlphaCloud: ds18b20 was running correctly from a configuration whose
+  file had been deleted. A restart would have regenerated a template — and a
+  generated template carries the authorizer slot empty, which means absent, so
+  the system would have come back up serving without checking a token and said
+  nothing about it. The reconstructed file is in place, but the hazard is
+  general and it fails open. A provider holding a CA-signed certificate has
+  evidence it once belonged to a cloud that had a CA; coming up with no
+  authorizer configured is at least worth a line in the log, and possibly worth
+  refusing until an operator says otherwise.
+
+- **A permission cannot be withdrawn from a system that is using it.** Removing
+  a rule from `policies.json` takes effect on the next decision, but a consumer
+  holding a token keeps working until it expires — five minutes for an actuation
+  on AlphaCloud. That is the same mechanism that lets a cell survive the
+  authorizer being down, so it is a trade rather than a defect, but there is no
+  way at present to say "stop now". A revocation list checked at the provider
+  would be the obvious answer and is not written.
 
 ## Not yet run on hardware
 

--- a/TODO.md
+++ b/TODO.md
@@ -73,6 +73,17 @@ say why here and then delete the entry.
   it, and nothing has yet loaded it into the AASX Package Explorer or FA³ST to
   confirm the shape is accepted rather than merely plausible.
 
+- **The service registrar cannot be put behind the authorizer as things stand.**
+  Two independent reasons, both found while writing AlphaCloud's policy file.
+  First, `RegisterServices` sends a bare POST and `unregisterService` a bare
+  DELETE — neither carries a token, and neither could obtain one, because a
+  token comes from orchestration and orchestration needs the registry. Second,
+  `ActionForMethod` maps DELETE to the empty string by design, so no token claim
+  can ever match a deregistration. Until both are answered, `esr` must stay out
+  of the core-system list of anything that would enforce against it, and the
+  aggregation systems reading `syslist` need no policy. Enable enforcement on
+  leaf providers — `ds18b20`, `parallax` — first.
+
 ## Not yet run on hardware
 
 The mission type, `ServicePointList_v1`, the cervice lock, the client transport

--- a/authorizer/POLICY.md
+++ b/authorizer/POLICY.md
@@ -246,6 +246,61 @@ and re-orchestrates only when that cache is empty
 (`usecases/consumption.go:51-56`), and nothing compels a client to consult the
 Orchestrator at all. A hand-written consumer can call any provider URL directly.
 
+### The bootstrap plane is exempt
+
+**A service whose effective mission is `core` is served without a token.**
+
+This is not a concession; without it authorization cannot be switched on at all.
+One configuration list, `Husk.CoreS`, says two different things: *this is the
+authorizer I verify against*, and *I demand tokens on my own services*. The
+Orchestrator must name the Authorizer to consult it — and doing so made
+`/squest` demand a token, when a service quest is precisely where a token comes
+from. Every discovery request would have been refused and no token could ever
+have been issued. The Service Registrar deadlocks the same way: `RegisterServices`
+sends a bare POST, and it could not do otherwise, since obtaining a token
+requires a registry to discover the provider in.
+
+So discovery, registration, certification and attestation are exempt. They are
+what make tokens possible and therefore cannot be gated by one.
+
+The exemption is decided on the **mission**, not on the system name, for two
+reasons. The mission is already the vocabulary policy is written in, so a core
+system that gains a service does not have to be remembered in a list. And a
+service's own mission overrides its asset's, so a core system offering something
+that is not core — a registrar publishing a temperature — has it gated like
+anything else. Without that, `core` would become a place to hide a service from
+policy.
+
+It is checked **before** the key is required, so a provider still fetching the
+Authorizer's public key answers core requests rather than 503. A registrar that
+refused registrations for the length of that fetch would make the cloud look as
+though it had to be started in a fixed order, which it does not.
+
+**State the boundary plainly: any system this cloud has enrolled may call a core
+service without a token.** It can register services, query the registry, request
+orchestration and ask the CA to certify it. What protects that plane is the layer
+beneath — mutual TLS with a certificate the CA signed only for a binary whose
+SHA-256 is on the whitelist (see *Composition with the security/ca whitelist*).
+Policy governs what a system may *do with* the cloud's assets; attestation
+governs whether it is in the cloud at all.
+
+This is not a hole a rogue provider can climb through by declaring itself core.
+Enforcement is already the provider's own choice — a system that did not want to
+check tokens would simply leave the Authorizer out of its configuration — so a
+provider calling its own service core weakens nothing that was not already its
+to weaken.
+
+Two consequences worth knowing before enabling anything:
+
+- The Registrar can be given the Authorizer in its core list, and registration
+  will still work. But **deregistration will not**: `ActionForMethod` maps DELETE
+  to the empty string by design, and no token claim can match it. A registrar's
+  `unregister` is core-mission and therefore exempt today; if that ever changes,
+  deregistration breaks.
+- Filtering at the Orchestrator still applies to core services. The exemption is
+  about the *provider's* token check, not about which candidates a consumer is
+  shown.
+
 ### Token delivery
 
 The token travels back to the consumer inside the orchestration response:

--- a/authorizer/POLICY.md
+++ b/authorizer/POLICY.md
@@ -324,6 +324,66 @@ needed.
 
 ## Deployment constraints
 
+### Reach the Orchestrator over HTTPS
+
+**A consumer whose `coreSystems` entry for the Orchestrator is `http://…` can
+never be authorized, however the policy file is written.**
+
+The subject is the Common Name of a verified client certificate, and a client
+certificate exists only on a mutual-TLS connection. A service quest that arrives
+over plain HTTP therefore carries no subject at all, the Authorizer is asked
+about `""`, and nothing in `policies.json` names `""` — so every candidate is
+refused and the consumer is told it may use none of them.
+
+This is not hypothetical; it is what the first enabled deployment did. The
+generated configuration seeds every core system over HTTP, which is correct for
+two of the three:
+
+| Core system | Scheme | Why |
+|---|---|---|
+| `ca` | **http** | Enrollment precedes any certificate. It cannot be otherwise. |
+| `serviceregistrar` | **http** | Registration is core-mission and needs no token. |
+| `orchestrator` | **https** once authorization is adopted | This is where the subject is established. |
+
+So exactly one line changes per consumer:
+
+```json
+{ "coreSystem": "orchestrator",
+  "url": "https://192.168.1.10:30103/orchestrator/orchestration" }
+```
+
+The address rather than `localhost`: the certificate the CA issues carries the
+host's addresses and never mentions `localhost`, so `https://localhost:30103`
+fails to verify. Generated configurations now seed the host's own address for
+this reason, and the HTTPS port is the HTTP port with its leading `2` replaced
+by a `3`.
+
+The failure is quiet from the consumer's side — it looks like a policy refusal,
+which sends an operator to the one file the answer is not in — so the
+Orchestrator now says so in the refusal it returns rather than only in its own
+log.
+
+### The authorizer slot in a generated configuration
+
+`systemconfig.json` is generated with a fourth core system:
+
+```json
+{ "coreSystem": "authorizer", "url": "" }
+```
+
+An empty URL means **absent**: a cloud that has not adopted authorization
+behaves exactly as it did before, and `GetRunningCoreSystemURL` skips the entry.
+What the slot buys is discovery — an operator opening the file sees that the
+framework has an authorizer and where its URL goes, rather than needing to know
+the JSON shape and copy it from another system.
+
+It is deliberately not seeded with a real URL. `AuthorizeRequest` does not check
+whether an authorizer is *reachable*, only whether one is *configured*, so a
+seeded URL would make every newly generated system answer 503 to everything but
+its core services until an authorizer existed — breaking every cloud that has
+not adopted authorization, which is the opposite of adoption per deployment.
+
+
 **One functional location per system.** The subject is a certificate CN, which
 identifies a *system*; attributes such as `FunctionalLocation` are declared on
 *unit assets*. A system whose assets sit in different locations therefore has no

--- a/authorizer/README.md
+++ b/authorizer/README.md
@@ -274,6 +274,37 @@ while the control loop runs on. That is the token doing its work: the decision
 is made once at discovery and checked locally at every provider thereafter, so
 a cell keeps running when the authorizer does not.
 
+### What it looks like when a token expires
+
+```
+14:39:11  ds18b20:    refusing GET .../temperature: the token expired at 14:39:01
+14:39:21  authorizer: "thermostat" may use 1 of 1 candidates for read
+14:40:09  thermostat: deviation -2.187, jitter 1.134 ms, valve 39%
+```
+
+Ten seconds, no intervention, no missed control cycle worth the name. The
+provider refused with 403, `askOneProvider` classified that as a stale provider,
+`forgetToken` dropped the credential for that one action, and the next call
+rediscovered and was issued a fresh one. Nothing was written for renewal: it
+falls out of treating a refused credential as a reason to discover again.
+
+This is also the cost side of the design stated plainly. A permission withdrawn
+from `policies.json` keeps working until the tokens holding it expire — five
+minutes for an actuation here — because that is the same mechanism. Revocation
+latency and outage tolerance are the same property seen from two directions.
+
+### What it looks like when a policy changes
+
+```
+14:37:23  authorizer: loaded 5 policies and 0 denials from policies.json
+14:37:23  authorizer: "painter" may use 1 of 1 candidates for read
+```
+
+No restart. `reloadPolicies` compares the file's modification time before each
+decision, so an edit takes effect on the next one. A file that does not parse
+leaves the previous rules in place rather than reverting to deny-everything,
+which would take a plant down over a typo.
+
 ## What remains
 
 - **No `policies.json` exists in most deployments.** AlphaCloud has one;
@@ -286,10 +317,11 @@ a cell keeps running when the authorizer does not.
   cross-compile it yet.
 - **Now run end to end on the testbed**, on AlphaCloud: a thermostat granted read
   on a measurement and write on an actuation, both paired by functional location,
-  driving a servo through a verified token. What has *not* been exercised is a
-  refusal in anger — every denial so far has been a misconfiguration rather than
-  a policy doing its job — nor a token expiring under load, nor a second
-  consumer competing for the same provider.
+  driving a servo through a verified token. Token renewal has since been
+  exercised in anger as well (see below). What has *not* been exercised is a
+  second consumer competing for the same provider, nor a policy narrowed while a
+  control loop runs — the hot reload is proven, revoking a permission somebody
+  is using is not.
 
 ## Related
 

--- a/authorizer/README.md
+++ b/authorizer/README.md
@@ -232,17 +232,64 @@ running deployment.
 5. **Tokens issued, relayed and verified at the provider.** Last, because it is
    the only step that can lock a running cloud out of itself.
 
+## Enabling it on a running cloud
+
+The order matters, because one list — `coreSystems` — says both *this is the
+authorizer I verify against* and *I demand tokens on my own services*.
+
+1. **Write `policies.json`** in the authorizer's working directory. Until one
+   exists every request is denied, which is correct for an uncommissioned cloud
+   and looks like a fault. The log says `loaded N policies and M denials`.
+2. **The consumers' Orchestrator URL becomes `https://<address>:301xx/…`.**
+   Without this nothing can be authorized at all — see POLICY.md, *Reach the
+   Orchestrator over HTTPS*. This is the step that is easy to miss and hard to
+   read from the symptom.
+3. **The Orchestrator names the authorizer.** Orchestration is now filtered: a
+   consumer is shown only the providers its policy permits, each with a token.
+   Nothing is enforced yet, so a mistake here costs a discovery, not a plant.
+4. **The providers name the authorizer.** They now verify. This is the step that
+   can lock a running cloud out of itself, so it goes last.
+
+Consumers need no change beyond step 2 — they relay the token they are handed.
+
+Leave `esr`, `ca` and `maitreD` out. They will work if added, since their
+services are core-mission and exempt, but there is no benefit and one sharp
+edge: deregistration is exempt only while `unregister` stays core-mission.
+
+Restart order does not matter. A provider that starts before the authorizer
+answers 503 and serves as soon as it has the key, retrying from a second.
+
+### What it looks like when it works
+
+```
+authorizer:    "thermostat" may use 1 of 1 candidates for read
+authorizer:    "thermostat" may use 1 of 1 candidates for write
+ds18b20:       ready to verify access tokens
+ds18b20:       first request to ds18b20 from peer "thermostat"
+parallax:      servo position changing to 26%
+```
+
+The Authorizer is consulted **once** and not again until the tokens expire,
+while the control loop runs on. That is the token doing its work: the decision
+is made once at discovery and checked locally at every provider thereafter, so
+a cell keeps running when the authorizer does not.
+
 ## What remains
 
-- **No `policies.json` exists in any deployment.** `*.json` is gitignored, so each
+- **No `policies.json` exists in most deployments.** AlphaCloud has one;
+  `policies.alphacloud.json` beside these files is the copy under test. `*.json` is gitignored, so each
   deployment writes its own; `writePoliciesTemplate` produces a loadable starting
   point. Until one exists the authorizer denies everything, which is the correct
   state for an uncommissioned cloud but will look like a fault.
 - **Not in the Makefile's `SYSTEMS` list**, so continuous integration (CI) does
   not lint, test or
   cross-compile it yet.
-- **Never run end to end on the testbed.** Every layer is unit-tested; none of it
-  has met a real Raspberry Pi.
+- **Now run end to end on the testbed**, on AlphaCloud: a thermostat granted read
+  on a measurement and write on an actuation, both paired by functional location,
+  driving a servo through a verified token. What has *not* been exercised is a
+  refusal in anger — every denial so far has been a misconfiguration rather than
+  a policy doing its job — nor a token expiring under load, nor a second
+  consumer competing for the same provider.
 
 ## Related
 

--- a/authorizer/alphacloud_test.go
+++ b/authorizer/alphacloud_test.go
@@ -32,7 +32,10 @@ const alphaCloudPolicies = `{
             "actions": ["read", "write"],
             "must_match_attribute": "FunctionalLocation",
             "ttl": "5m"
-        }
+        },
+        {"subject": "painter",  "missions": ["core"], "services": ["syslist"], "actions": ["read"], "ttl": "15m"},
+        {"subject": "kgrapher", "missions": ["core"], "services": ["syslist"], "actions": ["read"], "ttl": "15m"},
+        {"subject": "modeler",  "missions": ["core"], "services": ["syslist"], "actions": ["read"], "ttl": "15m"}
     ],
     "denials": []
 }`
@@ -86,11 +89,27 @@ func TestAlphaCloudDecisions(t *testing.T) {
 			Action: ActionWrite, Record: record("parallax", "Servo_1", "rotation", "actuation", at("Kitchen"))},
 		false,
 	}, {
-		// Nothing in this file mentions the aggregation systems, and the default
-		// is deny. They are unaffected today only because the registrar does not
-		// verify tokens; the moment it does, this is what they get.
-		"the painter cannot read the registry",
+		// The aggregation systems read the system list and nothing else. They
+		// would work without this — syslist is core-mission and served without a
+		// token — but the orchestrator still filters, so without a rule every
+		// walk is refused and logged, and a log full of denials that are not
+		// denials is how a real one gets missed.
+		"the painter may read the system list",
 		Request{Subject: "painter", SubjectAttributes: map[string][]string{}, Action: ActionRead,
+			Record: record("serviceregistrar", "registry", "syslist", "core", nil)},
+		true,
+	}, {
+		// Narrowed to that one service: reading the list of systems is not a
+		// reason to be handed the registrar's whole surface.
+		"the painter may not query the registry",
+		Request{Subject: "painter", SubjectAttributes: map[string][]string{}, Action: ActionRead,
+			Record: record("serviceregistrar", "registry", "query", "core", nil)},
+		false,
+	}, {
+		// And reading is not writing: nothing here lets an aggregator register
+		// or unregister anything.
+		"the painter may not write to the registry",
+		Request{Subject: "painter", SubjectAttributes: map[string][]string{}, Action: ActionWrite,
 			Record: record("serviceregistrar", "registry", "syslist", "core", nil)},
 		false,
 	}, {
@@ -105,9 +124,15 @@ func TestAlphaCloudDecisions(t *testing.T) {
 		if got.Allowed != tc.allowed {
 			t.Errorf("%s: allowed=%t, want %t (%s)", tc.name, got.Allowed, tc.allowed, got.Reason)
 		}
-		if got.Allowed && got.TTL.Minutes() != 5 {
-			t.Errorf("%s: ttl=%v, want the 5 minutes that bounds a stale permission on a valve",
-				tc.name, got.TTL)
+		// Five minutes bounds how long a stale permission can still drive a
+		// valve; fifteen is fine for a system that only reads a list, and costs
+		// the orchestrator less traffic.
+		wantTTL := 5.0
+		if tc.req.Subject != "thermostat" {
+			wantTTL = 15
+		}
+		if got.Allowed && got.TTL.Minutes() != wantTTL {
+			t.Errorf("%s: ttl=%v, want %v minutes", tc.name, got.TTL, wantTTL)
 		}
 	}
 }

--- a/authorizer/alphacloud_test.go
+++ b/authorizer/alphacloud_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// The AlphaCloud policy file, decided against the cloud that is actually
+// running on 192.168.1.10.
+//
+// The worked example in the README is written from the design; this is written
+// from the registry. Its records carry the missions and functional locations
+// those eleven systems registered on the day it was captured, so a rule that
+// looks right on paper and denies the thermostat its own valve fails here
+// rather than on the bench.
+//
+// The file itself lives in the authorizer's working directory on the Pi and is
+// gitignored, like every deployment's. This is the copy under test.
+const alphaCloudPolicies = `{
+    "policies": [
+        {
+            "subject": "thermostat",
+            "missions": ["measurement"],
+            "actions": ["read"],
+            "must_match_attribute": "FunctionalLocation",
+            "ttl": "5m"
+        },
+        {
+            "subject": "thermostat",
+            "missions": ["actuation"],
+            "actions": ["read", "write"],
+            "must_match_attribute": "FunctionalLocation",
+            "ttl": "5m"
+        }
+    ],
+    "denials": []
+}`
+
+func alphaCloud(t *testing.T) Policies {
+	t.Helper()
+	var p Policies
+	if err := json.Unmarshal([]byte(alphaCloudPolicies), &p); err != nil {
+		t.Fatalf("the policy file does not parse: %v", err)
+	}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("the policy file does not load: %v", err)
+	}
+	return p
+}
+
+func TestAlphaCloudDecisions(t *testing.T) {
+	p := alphaCloud(t)
+
+	cases := []struct {
+		name    string
+		req     Request
+		allowed bool
+	}{{
+		"the thermostat reads the temperature it controls on",
+		Request{Subject: "thermostat", SubjectAttributes: at("Kitchen"), Action: ActionRead,
+			Record: record("ds18b20", "28-00000f030344", "temperature", "measurement", at("Kitchen"))},
+		true,
+	}, {
+		"the thermostat drives the valve",
+		Request{Subject: "thermostat", SubjectAttributes: at("Kitchen"), Action: ActionWrite,
+			Record: record("parallax", "Servo_1", "rotation", "actuation", at("Kitchen"))},
+		true,
+	}, {
+		"the thermostat reads back the valve position",
+		Request{Subject: "thermostat", SubjectAttributes: at("Kitchen"), Action: ActionRead,
+			Record: record("parallax", "Servo_1", "rotation", "actuation", at("Kitchen"))},
+		true,
+	}, {
+		// The distinction the two split rules exist to make. One rule listing
+		// both missions and both actions would allow this.
+		"the thermostat cannot write to the sensor",
+		Request{Subject: "thermostat", SubjectAttributes: at("Kitchen"), Action: ActionWrite,
+			Record: record("ds18b20", "28-00000f030344", "temperature", "measurement", at("Kitchen"))},
+		false,
+	}, {
+		// The constraint comes from the registry, not the request: a thermostat
+		// cannot assert its way into another room.
+		"a bathroom thermostat cannot drive the kitchen valve",
+		Request{Subject: "thermostat", SubjectAttributes: at("Bathroom"),
+			Action: ActionWrite, Record: record("parallax", "Servo_1", "rotation", "actuation", at("Kitchen"))},
+		false,
+	}, {
+		// Nothing in this file mentions the aggregation systems, and the default
+		// is deny. They are unaffected today only because the registrar does not
+		// verify tokens; the moment it does, this is what they get.
+		"the painter cannot read the registry",
+		Request{Subject: "painter", SubjectAttributes: map[string][]string{}, Action: ActionRead,
+			Record: record("serviceregistrar", "registry", "syslist", "core", nil)},
+		false,
+	}, {
+		"an unknown system gets nothing",
+		Request{Subject: "intruder", SubjectAttributes: at("Kitchen"), Action: ActionRead,
+			Record: record("ds18b20", "28-00000f030344", "temperature", "measurement", at("Kitchen"))},
+		false,
+	}}
+
+	for _, tc := range cases {
+		got := Decide(p, tc.req)
+		if got.Allowed != tc.allowed {
+			t.Errorf("%s: allowed=%t, want %t (%s)", tc.name, got.Allowed, tc.allowed, got.Reason)
+		}
+		if got.Allowed && got.TTL.Minutes() != 5 {
+			t.Errorf("%s: ttl=%v, want the 5 minutes that bounds a stale permission on a valve",
+				tc.name, got.TTL)
+		}
+	}
+}
+
+// The file on the Pi and the file under test must be the same file. Kept beside
+// the tests rather than in the authorizer's working directory, because that one
+// is gitignored and a deployment's policy is not this repository's business —
+// but a copy nothing checks is a copy that drifts.
+func TestTheShippedExampleIsWhatIsTested(t *testing.T) {
+	onDisk, err := os.ReadFile("policies.alphacloud.json")
+	if err != nil {
+		t.Skipf("no example file to compare: %v", err)
+	}
+	var a, b Policies
+	if err := json.Unmarshal(onDisk, &a); err != nil {
+		t.Fatalf("the example file does not parse: %v", err)
+	}
+	if err := json.Unmarshal([]byte(alphaCloudPolicies), &b); err != nil {
+		t.Fatal(err)
+	}
+	x, _ := json.Marshal(a)
+	y, _ := json.Marshal(b)
+	if string(x) != string(y) {
+		t.Errorf("the example file and the tested policy have drifted apart:\n on disk: %s\n tested:  %s", x, y)
+	}
+}

--- a/authorizer/go.mod
+++ b/authorizer/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/authorizer
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/authorizer/go.sum
+++ b/authorizer/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/authorizer/thing.go
+++ b/authorizer/thing.go
@@ -78,7 +78,7 @@ func initTemplate() *components.UnitAsset {
 	authorize := components.Service{
 		Definition:  "authorize",
 		SubPath:     "authorize",
-		Details:     map[string][]string{"Forms": {"AuthorizationQuest_v1"}},
+		Details:     map[string][]string{"Forms": {"AuthorizationQuest_v1"}, "Methods": components.HTTPMethods("POST")},
 		RegPeriod:   30,
 		Description: "decides (POST) which of a set of candidate providers a subject may use",
 	}

--- a/authorizer/thing.go
+++ b/authorizer/thing.go
@@ -324,7 +324,7 @@ func (t *Traits) orchestratorCN() string {
 // Reading the current port meant the refusal could switch itself off. The
 // HTTPS server releases its entry when it returns, so an authorizer that had
 // been refusing plaintext for weeks would start accepting it again after a cert
-// rotation or a cancelled context, while continuing to serve on the plain port.
+// rotation or a canceled context, while continuing to serve on the plain port.
 // EverBound is the latch: once TLS has been served, it stays served as far as
 // this decision is concerned.
 // The window before TLS first binds is deliberately still open: there is no

--- a/authorizer/thing_test.go
+++ b/authorizer/thing_test.go
@@ -327,7 +327,7 @@ func TestPlaintextQuestsAreRefusedOnceTLSIsServing(t *testing.T) {
 		t.Errorf("the refusal does not name the remedy: %s", strings.TrimSpace(body))
 	}
 
-	// The TLS server stops — a certificate rotation, a port taken, a cancelled
+	// The TLS server stops — a certificate rotation, a port taken, a canceled
 	// context. SetoutServers releases the entry on its way out, so a check that
 	// reads the port being served now goes back to zero and the authorizer
 	// silently starts answering plaintext quests again, on a plain port that is

--- a/beehive/go.mod
+++ b/beehive/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/beehive
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/beehive/go.sum
+++ b/beehive/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/beehive/thing.go
+++ b/beehive/thing.go
@@ -79,7 +79,7 @@ func initTemplate() *components.UnitAsset {
 			"state": &components.Service{
 				Definition:  "SwitchList",
 				SubPath:     "state",
-				Details:     map[string][]string{"Forms": {"application/json"}},
+				Details:     map[string][]string{"Forms": {"application/json"}, "Methods": components.HTTPMethods("PUT")},
 				RegPeriod:   30,
 				Description: "lists the discovered switches and their last known state (GET)",
 			},
@@ -90,7 +90,7 @@ func initTemplate() *components.UnitAsset {
 				// so: this service drives a plug, and a mission is what the
 				// authorizer writes policy against.
 				Mission:     components.MissionActuation,
-				Details:     map[string][]string{"Forms": {"SignalB_v1a"}},
+				Details:     map[string][]string{"Forms": {"SignalB_v1a"}, "Methods": components.HTTPMethods("PUT")},
 				RegPeriod:   30,
 				Description: "switches a discovered device on or off (PUT ?name=<device>&value=<true|false>)",
 			},

--- a/beekeeper/go.mod
+++ b/beekeeper/go.mod
@@ -4,5 +4,5 @@ go 1.26.6
 
 require (
 	github.com/gorilla/websocket v1.5.3
-	github.com/sdoque/mbaigo v0.1.0-alpha.9
+	github.com/sdoque/mbaigo v0.1.0-alpha.10
 )

--- a/beekeeper/go.sum
+++ b/beekeeper/go.sum
@@ -4,3 +4,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/beekeeper/models.go
+++ b/beekeeper/models.go
@@ -146,6 +146,20 @@ func missionForService(subPath string) (components.Mission, error) {
 	return components.Mission{}, fmt.Errorf("service %q has no mission: add it to serviceMissions", subPath)
 }
 
+// methodsFor says which HTTP methods a service subpath answers.
+//
+// Only on_off can be driven — serving() refuses a PUT to anything else — so
+// only on_off says it accepts one. Deriving it here rather than listing it
+// beside each spec keeps the two statements in one place: the handler and the
+// registration would otherwise be free to disagree about which lights can be
+// switched.
+func methodsFor(subPath string) []string {
+	if subPath == "on_off" {
+		return components.HTTPMethods("GET", "PUT")
+	}
+	return components.HTTPMethods("GET")
+}
+
 // serviceSpec defines the Arrowhead service metadata for each service subpath.
 type serviceSpec struct {
 	definition  string

--- a/beekeeper/thing.go
+++ b/beekeeper/thing.go
@@ -33,11 +33,20 @@ import (
 
 // DeconzConfig holds the connection parameters for the deCONZ gateway.
 type DeconzConfig struct {
-	Host    string        `json:"host"`
-	APIPort int           `json:"apiPort"`
-	WSPort  int           `json:"wsPort"`
-	APIKey  string        `json:"apiKey"`
-	Period  time.Duration `json:"period"` // REST poll interval in seconds
+	Host    string `json:"host"`
+	APIPort int    `json:"apiPort"`
+	WSPort  int    `json:"wsPort"`
+	APIKey  string `json:"apiKey"`
+	// Period is the sampling period in seconds.
+	//
+	// An int rather than a time.Duration, because a Duration holding the number
+	// 10 means ten nanoseconds and only becomes ten seconds when multiplied by
+	// time.Second — which works, and reads as if the field were already a
+	// duration. Anyone writing the obvious `Period: time.Second` for one second
+	// would get 10^9 seconds, about 31 years, and the compiler would not object.
+	// The unit belongs in the name and the conversion belongs at the point of
+	// use.
+	Period int `json:"period"`
 }
 
 func (c DeconzConfig) apiBase() string {
@@ -379,7 +388,7 @@ func getJSON(url string, target interface{}) error {
 // pollREST periodically refreshes the cache from the deCONZ REST API.
 // This is a fallback for devices whose WebSocket events are missed during reconnection gaps.
 func pollREST(ctx context.Context, cfg DeconzConfig, cache *DeviceCache, assetIndex map[string]string) {
-	period := cfg.Period * time.Second
+	period := time.Duration(cfg.Period) * time.Second
 	if period <= 0 {
 		period = 30 * time.Second
 	}

--- a/beekeeper/thing.go
+++ b/beekeeper/thing.go
@@ -317,7 +317,7 @@ func newDeviceAsset(assetName, displayName string, services []string, lightID st
 			Definition:  spec.definition,
 			SubPath:     svc,
 			Mission:     mission,
-			Details:     map[string][]string{"Unit": {spec.unit}, "Forms": {"SignalA_v1a"}},
+			Details:     map[string][]string{"Unit": {spec.unit}, "Forms": {"SignalA_v1a"}, "Methods": methodsFor(svc)},
 			RegPeriod:   30,
 			Description: spec.description,
 		}

--- a/busdriver/can_other.go
+++ b/busdriver/can_other.go
@@ -36,7 +36,7 @@ func openCAN(ifname string) (int, error) {
 
 func closeCAN(_ int) {}
 
-// canPoller is a no-op stub: it blocks until the context is cancelled so the
+// canPoller is a no-op stub: it blocks until the context is canceled so the
 // goroutine started by newResource exits cleanly on shutdown.
 func canPoller(ctx context.Context, _ int, _ []pidSubscription) {
 	<-ctx.Done()

--- a/busdriver/go.mod
+++ b/busdriver/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/busdriver
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/busdriver/go.sum
+++ b/busdriver/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/busdriver/thing.go
+++ b/busdriver/thing.go
@@ -269,7 +269,7 @@ func (t *Traits) assetLoop(ctx context.Context) {
 			var f forms.SignalA_v1a
 			f.NewForm()
 			f.Value = t.value
-			f.Unit = t.unit
+			f.Unit = usecases.UnitIRI(t.unit)
 			f.Timestamp = t.tStamp
 			order.ValueP <- f
 		}

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()                                          // make sure all paths cancel the context to avoid context leak
 
 	// instantiate the System

--- a/ca/go.mod
+++ b/ca/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/ca
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/ca/go.sum
+++ b/ca/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/ca/thing.go
+++ b/ca/thing.go
@@ -93,7 +93,7 @@ func initTemplate() *components.UnitAsset {
 	certify := components.Service{
 		Definition:  "certify",
 		SubPath:     "certify",
-		Details:     map[string][]string{"Forms": {"csr.pem"}},
+		Details:     map[string][]string{"Forms": {"csr.pem"}, "Methods": components.HTTPMethods("POST")},
 		RegPeriod:   30,
 		Description: "signs a certificate signing request (POST) from authenticated systems in its local cloud",
 	}

--- a/clerk/go.mod
+++ b/clerk/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/clerk
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/clerk/go.sum
+++ b/clerk/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/clerk/thing.go
+++ b/clerk/thing.go
@@ -76,7 +76,7 @@ func initTemplate() *components.UnitAsset {
 	ordersService := components.Service{
 		Definition:  "orders",
 		SubPath:     "orders",
-		Details:     map[string][]string{"Forms": {"PenHolderOrder_v1"}},
+		Details:     map[string][]string{"Forms": {"PenHolderOrder_v1"}, "Methods": components.HTTPMethods("GET", "POST")},
 		RegPeriod:   60,
 		Description: "browser order form (GET), submit new order (POST), look up order (GET ?id=N)",
 	}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()                                          // make sure all paths cancel the context to avoid context leak
 
 	// instantiate the System

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -4,7 +4,7 @@ go 1.26.6
 
 require (
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
-	github.com/sdoque/mbaigo v0.1.0-alpha.9
+	github.com/sdoque/mbaigo v0.1.0-alpha.10
 )
 
 require (

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -20,6 +20,8 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/collector/thing.go
+++ b/collector/thing.go
@@ -39,7 +39,16 @@ import (
 type MeasurementT struct {
 	Name    string              `json:"serviceDefinition"`
 	Details map[string][]string `json:"mdetails"`
-	Period  time.Duration       `json:"samplingPeriod"`
+	// Period is the sampling period in seconds.
+	//
+	// An int rather than a time.Duration, because a Duration holding the number
+	// 10 means ten nanoseconds and only becomes ten seconds when multiplied by
+	// time.Second — which works, and reads as if the field were already a
+	// duration. Anyone writing the obvious `Period: time.Second` for one second
+	// would get 10^9 seconds, about 31 years, and the compiler would not object.
+	// The unit belongs in the name and the conversion belongs at the point of
+	// use.
+	Period int `json:"samplingPeriod"`
 }
 
 //-------------------------------------Define the unit asset
@@ -155,7 +164,7 @@ func newResource(configuredAsset usecases.ConfigurableAsset, sys *components.Sys
 			if err := t.collectIngest(name, period, writeAPI); err != nil {
 				log.Printf("Error in collectIngest for measurement: %v", err)
 			}
-		}(measurement.Name, measurement.Period*time.Second)
+		}(measurement.Name, time.Duration(measurement.Period)*time.Second)
 	}
 
 	return ua, func() {

--- a/democrat/README.md
+++ b/democrat/README.md
@@ -197,9 +197,12 @@ AAS  urn:alc:aas:<SystemName>
  │    ├─ HostName    (xs:string)
  │    ├─ IP_1        (xs:string)
  │    └─ IP_2 ...
- └─ Submodel: Services
-      ├─ ServiceUrl_<name>   (xs:anyURI)  ← one per service name
-      └─ <Definition>Url     (xs:anyURI)  ← shortcut when definition is unique
+ ├─ Submodel: Services
+ │    ├─ ServiceUrl_<name>   (xs:anyURI)  ← one per service name
+ │    ├─ Methods_<name>      (xs:string)  ← when the service answers more than GET
+ │    └─ <Definition>Url     (xs:anyURI)  ← shortcut when definition is unique
+ └─ Submodel: AssetInterfacesDescription  ← IDTA 02017-1-0, see below
+      └─ Interface<PROTOCOL> ...          ← one per protocol the husk opens
 ```
 
 Example for a `thermostat` system with one temperature service:
@@ -221,6 +224,11 @@ The `TemperatureUrl` shortcut appears because there is exactly one service with
 definition `"temperature"`.  When a system has two services with the same
 definition (e.g. a modboss with multiple `OnOff` coils), only the per-name
 properties are generated — no ambiguous shortcut.
+
+A fourth submodel, the **Asset Interfaces Description**, is added for any system
+whose services have an address.  It is described further down, because it is the
+only one here that implements a published template rather than a local
+convention.
 
 ---
 
@@ -279,8 +287,121 @@ so a consumer that has never seen an Arrowhead cloud can still find out what
 `afo:hasServiceDefinition` means.
 
 `TestEverySubmodelAndPropertyMeansSomething` walks the whole generated
-environment rather than naming elements, so a submodel or property added later
-without a meaning fails in the test run instead of reaching a data space.
+environment — recursively, since the interface description below nests four deep
+— rather than naming elements, so an element added later without a meaning fails
+in the test run instead of reaching a data space.
+
+---
+
+## The Asset Interfaces Description
+
+The three submodels above are the local cloud's own.  This one is not.
+
+[IDTA 02017-1-0](https://industrialdigitaltwin.org/en/content-hub/submodels) is
+a published submodel template, built on the W3C Web of Things Thing Description,
+for saying how to talk to an asset.  An Arrowhead service registration turns out
+to hold nearly everything it asks for — and three of the mappings are exact
+rather than approximate:
+
+| AID element | its semanticId | comes from |
+|---|---|---|
+| `observable` | `wot/td#isObservable` | `afo:isSubscribable` |
+| `unit` | `schema.org/unitCode` | the QUDT unit IRI |
+| `valueSemantics` | `.../1/0/valueSemantics` | the QUDT quantity kind |
+
+`observable` in the Web of Things means a value you may follow rather than poll,
+which is what mbaigo's subscription is; `unitCode` explicitly admits a URL, so
+the QUDT IRI goes in whole instead of being flattened to a three-letter code;
+and `valueSemantics` is a reference element that exists to point at what a value
+means, which is exactly a quantity kind.  Nothing had to be bent to fit.
+
+This is therefore the first submodel democrat emits that is entitled to an
+`admin-shell.io` semanticId — it carries them because it implements the
+template, not because they look more official than a local identifier.
+
+For a thermostat listening on both ports:
+
+```
+AssetInterfacesDescription
+ ├─ InterfaceHTTP                    ← one interface per protocol the husk opens
+ │   ├─ title              "thermostat"
+ │   ├─ EndpointMetadata
+ │   │   ├─ base           "http://192.168.1.10:20185/thermostat/"
+ │   │   ├─ contentType    "application/json"
+ │   │   └─ securityDefinitions → nosec_sc
+ │   └─ InteractionMetadata / properties / controller_setpoint
+ │        ├─ key            "setpoint"
+ │        ├─ type           "number"          ← from the payload form
+ │        ├─ title          "controller/setpoint"
+ │        ├─ observable     true
+ │        ├─ unit           "http://qudt.org/vocab/unit/DEG_C"
+ │        ├─ valueSemantics → quantitykind/ThermodynamicTemperature
+ │        └─ forms
+ │             ├─ href           "controller/setpoint"   ← relative to base
+ │             ├─ contentType    "application/json"
+ │             └─ htv_methodName "GET"
+ └─ InterfaceHTTPS                   ← same properties, different security
+     └─ EndpointMetadata / securityDefinitions → auto_sc
+```
+
+Two decisions in there are worth stating rather than leaving to be discovered.
+
+**Security.**  The Web of Things offers `nosec`, `basic`, `digest`, `bearer`,
+`psk`, `apikey`, `oauth2`, `combo` and `auto`.  None of them is "mutual TLS with
+a cloud certificate authority, plus a per-action token from the authorizer".  So
+the plain HTTP interface says `nosec_sc`, which is simply true — that port is
+unauthenticated — and the HTTPS interface says `auto_sc`, the Web of Things term
+for security arranged out of band.  That is honest about being underspecified.
+Claiming `bearer_sc` would have described the token and quietly dropped the
+certificate, and the certificate is the half that decides whether a connection
+happens at all.
+
+**Methods.**  AID 1.0 gives a property exactly one `forms` collection and that
+form one `htv_methodName`, so a setpoint answering both GET and PUT cannot state
+both there.  The form carries the method a consumer reads with — or the only
+method, when the service does not read at all, since calling beehive's `toggle`
+a GET would be worse than saying nothing.  What the template cannot hold is not
+thrown away: the Services submodel carries the complete list.
+
+```
+Services
+ ├─ Methods_controller_setpoint  "GET PUT"     ← semanticId alc:hasMethods
+ └─ ServiceUrl_controller_setpoint  "https://…"
+```
+
+A consumer reading only the interface description learns how to read the value;
+one reading the whole shell learns that the setpoint can also be written.
+
+### Where the methods come from
+
+Until recently nothing outside a provider's own `serving` switch knew that a
+service could be written to.  The registration form did not carry it, the graph
+did not say it, and the only record that a setpoint was settable was the English
+in the service's `Description` — which never leaves the binary.  A consumer had
+to send a PUT and read the status code.
+
+`Details["Methods"]` now carries it, as W3C HTTP method IRIs:
+
+```go
+Details: map[string][]string{
+    "Unit":    {"<http://qudt.org/vocab/unit/DEG_C>"},
+    "Methods": components.HTTPMethods("GET", "PUT"),
+},
+```
+
+IRIs rather than the bare strings, for the same reason `Unit` carries a QUDT IRI
+instead of the word "Celsius": a detail value that looks like a name is written
+into the graph as an entity in the local cloud's namespace — `alc:GET`, a thing
+this cloud would have invented to stand for something the W3C already named.
+
+Where the truth already exists in configuration it is derived rather than
+restated: modboss reads it from the register map's access mode, uaclient from
+the node's OPC UA access level, and beekeeper from the subpath.  A second place
+to state it is a second place to be wrong.
+
+The predicate reaches the graph as `alc:hasMethods`, since AFO does not define
+it.  That makes it a candidate for the next ontology release, at which point it
+becomes `afo:hasMethods` and one line changes in `kgraphing.go`.
 
 ---
 
@@ -293,6 +414,7 @@ without a meaning fails in the test run instead of reaching a data space.
 | `democrat.go` | `main()` bootstrap, `serving()` dispatcher, `syncHandler`, `statusHandler` |
 | `thing.go` | `DemocratConfig`, `Traits`, `SyncResult`, `initTemplate`, `newResource`, `syncLoop`, `runSync` |
 | `aas.go` | AAS/Submodel types, SPARQL helpers, `loadSystems`, `buildAASEnv`, `upsertShell`, `upsertSubmodel` — no build constraints |
+| `aid.go` | The Asset Interfaces Description: IDTA 02017-1-0 and Web of Things identifiers, `buildAID` and the elements below it |
 
 ### Concurrency
 
@@ -490,7 +612,14 @@ go test ./...
 | `TestBuildAASEnv_EmptyInput` | Empty map → empty AASEnv |
 | `TestBuildAASEnv_StableOrder` | Output is deterministic across calls |
 | `TestEverySubmodelAndPropertyMeansSomething` | Every submodel and property carries a dereferenceable `semanticId` |
-| `TestTheMeaningsComeFromTheOntologyTheValuesCameFrom` | The identifiers are AFO's own, and nothing claims an IDTA template |
+| `TestTheMeaningsComeFromTheOntologyTheValuesCameFrom` | The local submodels use AFO's identifiers; only the AID claims an IDTA template |
+| `TestOneInterfacePerProtocol` | http and https become separate interfaces, with their own base and security |
+| `TestTheExactMappings` | `observable`, `unit` and `valueSemantics` still come from subscribability, QUDT unit and quantity kind |
+| `TestHrefIsRelativeToTheBase` | A form's href does not repeat the host |
+| `TestAWriteIsNotSilentlyDropped` | The form states the read method; the Services submodel states all of them |
+| `TestAServiceThatOnlyWritesSaysSo` | A PUT-only service is not described as readable |
+| `TestSilenceAboutMethodsStaysSilent` | A service that declared no methods gets no claim made for it |
+| `TestNoAddressNoInterfaceDescription` | A system with no addresses gets no empty interface description |
 | `TestInitTemplate` | Name, both services, non-empty URLs |
 | `TestServing_InvalidPath` | Unknown path → 400 |
 | `TestStatusHandler_MethodNotAllowed` | POST → 405 |

--- a/democrat/README.md
+++ b/democrat/README.md
@@ -50,8 +50,9 @@ automatically.  **No information is entered twice.**
 │                         Arrowhead local cloud                           │
 │                                                                         │
 │  ds18b20 ──┐                                                            │
-│  thermostat├──► Service Registrar ──► kgrapher ──► GraphDB             │
+│  thermostat├──► Service Registrar ──► kgrapher ──► GraphDB              │
 │  modboss  ──┘        (registry)       (harvest)   (knowledge graph)     │
+│                                    (notifies on change)                 │
 │  ...                                                                    │
 └───────────────────────────────────────────────────┬─────────────────────┘
                                                     │ SPARQL SELECT
@@ -72,13 +73,22 @@ automatically.  **No information is entered twice.**
 When a new system joins the cloud:
 
 1. It starts, registers its services with the Service Registrar.
-2. A browser request to kgrapher (or its periodic refresh) harvests the new
-   system into the knowledge graph snapshot in GraphDB.
+2. The Service Registrar notifies kgrapher that the registry changed, and
+   kgrapher harvests the new system into the knowledge graph snapshot in
+   GraphDB.
 3. Democrat's background sync (every `syncInterval` seconds, default 5 minutes)
    queries GraphDB, builds an AAS for the new system, and upserts it into
    FA³ST.
 
 The engineer does nothing beyond step 1.
+
+The registrar-to-kgrapher step used to be a poll, and the graph was therefore
+only as fresh as the last time somebody opened kgrapher's page.  It is now
+driven by the registrar's own subscription: kgrapher rebuilds when the registry
+changes, so the snapshot democrat reads is current rather than merely recent.
+That matters here more than it does for a browser looking at a graph — democrat
+publishes into an AAS store that other organizations read, and a stale shell
+that still lists a system which left the cloud is worse than no shell at all.
 
 ---
 
@@ -128,6 +138,50 @@ SELECT ?system ?svcName ?svcDef ?url FROM <urn:state:current> WHERE {
 The `FROM <urn:state:current>` clause ensures democrat reads the latest
 consistent snapshot written by kgrapher, not a partial or historical state.
 
+### The graph holds more than the running cloud
+
+Everything above is the **runtime view**: what is deployed, where it runs, what
+it offers.  It is the view mbaigo can produce by itself, because it is the only
+view mbaigo knows anything about.  A `ds18b20` can say it provides a temperature
+service at a URL; it cannot say which tag on the P&ID it was installed against,
+who manufactured it, or what its serial number is.  Nothing in a
+`systemconfig.json` carries that.
+
+But the triple store democrat reads is not restricted to what kgrapher writes.
+The same GraphDB repository can hold the **plant-design view** (a DEXPI-based
+P&ID model, loaded once per design revision) and the **lifecycle view** (STEP
+AP4K instance records, updated as physical units are installed or replaced),
+aligned to the runtime view through the ISO 23726-3 Industrial Data Ontology.
+That alignment is the subject of:
+
+> Wintercorn, O., & van Deventer, J. A. *Ontology Alignment for Co-Engineering:
+> Integrating Plant Design, Lifecycle, and Runtime Views through IDO*.
+> (See `Research/GitPub/alignment`.)
+
+The consequence for democrat is concrete.  With the three views in one
+repository and one hand-authored `afo-lis:hasFunctionalLocation` assertion per
+deployed unit asset, a single query goes from a registered service, through the
+P&ID tag it was installed against, to the serial number of the unit physically
+installed at that position today:
+
+```sparql
+SELECT ?svc ?tag ?unit WHERE {
+  ?ua afo:providesService ?svc ;
+      afo-lis:hasFunctionalLocation ?tag ;
+      afo-lis:currentPhysicalUnit ?unit .
+}
+```
+
+Democrat does not run that query yet — it reads the runtime view only.  It is
+worth saying plainly what that changes: an AAS **Digital Nameplate** submodel
+needs a manufacturer, a serial number and a year of construction, and the
+correct statement is not that this data does not exist but that *mbaigo* does
+not have it.  The graph can.  When democrat is extended to a Nameplate submodel,
+the data will come from the lifecycle view through these bridges rather than
+from anything an Arrowhead system says about itself — which is the right place
+for it, since a system that is replaced by an identical spare keeps its
+configuration and changes its serial number.
+
 ---
 
 ## What democrat generates
@@ -167,6 +221,66 @@ The `TemperatureUrl` shortcut appears because there is exactly one service with
 definition `"temperature"`.  When a system has two services with the same
 definition (e.g. a modboss with multiple `OnOff` coils), only the per-name
 properties are generated — no ambiguous shortcut.
+
+---
+
+## What makes a shell consumable: semanticIds
+
+An AAS that parses is not the same thing as an AAS that can be used.  Given a
+property called `ServiceUrl_thermostat_temperature`, a consumer can display the
+string and do nothing else with it: there is nothing to look up, nothing to
+compare against another vendor's shell, and no way to tell a URL from a serial
+number except by reading the name and guessing.  Element names are for people.
+
+Every submodel and every property democrat writes therefore carries a
+`semanticId` — a reference to the concept the value came from:
+
+```json
+{
+  "modelType": "Property",
+  "idShort": "TemperatureUrl",
+  "valueType": "xs:anyURI",
+  "value": "https://192.168.1.10:30150/ds18b20/28-00000f030344/temperature",
+  "semanticId": {
+    "type": "ExternalReference",
+    "keys": [
+      { "type": "GlobalReference",
+        "value": "http://www.synecdoque.com/2025/afo#hasServiceDefinition" }
+    ]
+  }
+}
+```
+
+The identifiers are the **ontology's own predicate IRIs**, because that is
+literally where the values came from: democrat reads a knowledge graph, and each
+property is a literal that was the object of exactly one predicate.  Pointing at
+that predicate is both true and useful.
+
+| Element | Means |
+|---|---|
+| `Identity` submodel | `alc:aas/IdentitySubmodel` |
+| `Host` submodel | `alc:aas/HostSubmodel` |
+| `Services` submodel | `alc:aas/ServicesSubmodel` |
+| `SystemName`, `HostName` | `afo:hasName` |
+| `SystemUri` | `afo:System` |
+| `IP_n` | `afo:hasIPAddress` |
+| `ServiceUrl_<name>` | `afo:hasUrl` |
+| `<Definition>Url` | `afo:hasServiceDefinition` |
+
+The three submodel identifiers are minted in the local cloud's own namespace and
+are honest about being local.  No IDTA submodel template describes an Arrowhead
+system, and naming one anyway — pointing at an `admin-shell.io` template
+identifier because it looks more official — would claim conformance to a
+template democrat does not implement.  A local identifier that is true is worth
+more in a data space than a standard identifier that is false.
+
+The AFO identifiers, by contrast, are dereferenceable and published with a DOI,
+so a consumer that has never seen an Arrowhead cloud can still find out what
+`afo:hasServiceDefinition` means.
+
+`TestEverySubmodelAndPropertyMeansSomething` walks the whole generated
+environment rather than naming elements, so a submodel or property added later
+without a meaning fails in the test run instead of reaching a data space.
 
 ---
 
@@ -375,6 +489,8 @@ go test ./...
 | `TestBuildAASEnv_DefinitionShortcut_NotUniqueIsSkipped` | Non-unique def → no shortcut |
 | `TestBuildAASEnv_EmptyInput` | Empty map → empty AASEnv |
 | `TestBuildAASEnv_StableOrder` | Output is deterministic across calls |
+| `TestEverySubmodelAndPropertyMeansSomething` | Every submodel and property carries a dereferenceable `semanticId` |
+| `TestTheMeaningsComeFromTheOntologyTheValuesCameFrom` | The identifiers are AFO's own, and nothing claims an IDTA template |
 | `TestInitTemplate` | Name, both services, non-empty URLs |
 | `TestServing_InvalidPath` | Unknown path → 400 |
 | `TestStatusHandler_MethodNotAllowed` | POST → 405 |

--- a/democrat/README.md
+++ b/democrat/README.md
@@ -372,6 +372,78 @@ Services
 A consumer reading only the interface description learns how to read the value;
 one reading the whole shell learns that the setpoint can also be written.
 
+## Concept descriptions: the meanings, brought inside
+
+A semanticId is a promise that somebody, somewhere, wrote down what the
+identifier stands for.  A **ConceptDescription** is that writing-down brought
+into the environment, so a consumer with no internet — or no interest in
+dereferencing an IRI it has never seen — can still learn that a value is a
+temperature in degrees Celsius.
+
+The rule for what gets one is *describe what only we can describe*.
+
+| Identifier | Described here? | Why |
+|---|---|---|
+| `alc:aas/IdentitySubmodel` and the other local templates | yes | Nothing else in the world defines them |
+| `alc:hasMethods` | yes | Same |
+| QUDT units | yes | For the IEC 61360 translation, not the definition |
+| QUDT quantity kinds | yes | Same |
+| `afo:hasName`, `afo:hasUrl`, … | **no** | AFO is published with a DOI and defines its own terms |
+| `admin-shell.io/…`, `w3.org/…` | **no** | Not ours to define |
+
+The AFO exclusion is the interesting one.  Copying those definitions into every
+shell would be exactly the duplication democrat exists to remove, and the copies
+would drift the first time the ontology was revised.  The IRIs dereference; that
+is enough.
+
+The QUDT entries are not a redefinition either.  QUDT is authoritative and does
+dereference — but it does not publish *"°C, and formally this IRI"* in the shape
+the Asset Administration Shell world reads.  IEC 61360 has exactly that shape,
+and this bridge is the only place the pairing can be made:
+
+```json
+{
+  "modelType": "ConceptDescription",
+  "id": "http://qudt.org/vocab/unit/DEG_C",
+  "idShort": "DEG_C",
+  "embeddedDataSpecifications": [{
+    "dataSpecification": { "type": "ExternalReference", "keys": [{ "type": "GlobalReference",
+      "value": "https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0" }]},
+    "dataSpecificationContent": {
+      "modelType": "DataSpecificationIec61360",
+      "preferredName": [{ "language": "en", "text": "DEG_C" }],
+      "shortName":     [{ "language": "en", "text": "°C" }],
+      "unit":   "°C",
+      "unitId": { "type": "ExternalReference", "keys": [{ "type": "GlobalReference",
+        "value": "http://qudt.org/vocab/unit/DEG_C" }]},
+      "dataType": "REAL_MEASURE",
+      "definition": [{ "language": "en",
+        "text": "The QUDT unit DEG_C, which measures ThermodynamicTemperature." }]
+    }
+  }]
+}
+```
+
+The symbol comes from the framework's own unit table — the one its conversions
+use — via `usecases.LookupUnit`, rather than from a second table here that could
+disagree with it.  A unit the framework does not know is left undescribed: an
+invented symbol would be worse than a consumer following the IRI.
+
+A quantity kind gets a description with no unit and no data type.  It says what
+a value *is*, not what it is counted in, and filling those fields would be
+describing the wrong thing.
+
+`buildConceptDescriptions` walks the environment it was handed rather than being
+given a list, so a submodel or property added later brings its concept along
+instead of leaving a semanticId pointing at nothing.
+`TestNoLocalIdentifierDangles` holds that invariant.
+
+They are written to FA³ST **before** the shells and submodels that point at
+them, so a consumer reading the store between two writes finds a semanticId that
+already resolves.
+
+---
+
 ### Where the methods come from
 
 Until recently nothing outside a provider's own `serving` switch knew that a
@@ -415,6 +487,7 @@ becomes `afo:hasMethods` and one line changes in `kgraphing.go`.
 | `thing.go` | `DemocratConfig`, `Traits`, `SyncResult`, `initTemplate`, `newResource`, `syncLoop`, `runSync` |
 | `aas.go` | AAS/Submodel types, SPARQL helpers, `loadSystems`, `buildAASEnv`, `upsertShell`, `upsertSubmodel` — no build constraints |
 | `aid.go` | The Asset Interfaces Description: IDTA 02017-1-0 and Web of Things identifiers, `buildAID` and the elements below it |
+| `concepts.go` | ConceptDescriptions: what the identifiers mean, in IEC 61360, for the ones this bridge is entitled to explain |
 
 ### Concurrency
 
@@ -620,6 +693,12 @@ go test ./...
 | `TestAServiceThatOnlyWritesSaysSo` | A PUT-only service is not described as readable |
 | `TestSilenceAboutMethodsStaysSilent` | A service that declared no methods gets no claim made for it |
 | `TestNoAddressNoInterfaceDescription` | A system with no addresses gets no empty interface description |
+| `TestOnlyWhatThisBridgeCanSpeakFor` | AFO, IDTA and W3C terms are left to their publishers |
+| `TestNoLocalIdentifierDangles` | Every `alc:` semanticId resolves inside the environment |
+| `TestAUnitCarriesItsSymbolAndItsIRI` | `unit`, `unitId`, `REAL_MEASURE` and a language-tagged name |
+| `TestSymbolsComeFromTheTableTheConversionsUse` | An unknown unit is left undescribed, not invented |
+| `TestAQuantityKindCarriesNoUnit` | A quantity kind is not a value |
+| `TestEachConceptIsDescribedOnce` | Two services in °C produce one description of it |
 | `TestInitTemplate` | Name, both services, non-empty URLs |
 | `TestServing_InvalidPath` | Unknown path → 400 |
 | `TestStatusHandler_MethodNotAllowed` | POST → 405 |

--- a/democrat/aas.go
+++ b/democrat/aas.go
@@ -76,14 +76,40 @@ type Submodel struct {
 	ModelType        string            `json:"modelType"`
 	ID               string            `json:"id"`
 	IDShort          string            `json:"idShort"`
+	SemanticID       *Reference        `json:"semanticId,omitempty"`
 	SubmodelElements []SubmodelElement `json:"submodelElements"`
 }
 
 type SubmodelElement struct {
-	ModelType string `json:"modelType"`
-	IDShort   string `json:"idShort"`
-	ValueType string `json:"valueType"`
-	Value     any    `json:"value,omitempty"`
+	ModelType  string     `json:"modelType"`
+	IDShort    string     `json:"idShort"`
+	SemanticID *Reference `json:"semanticId,omitempty"`
+	ValueType  string     `json:"valueType"`
+	Value      any        `json:"value,omitempty"`
+}
+
+// Reference points at the concept an element means, rather than at another
+// element of this shell.
+//
+// An ExternalReference, because what it names lives outside the Asset
+// Administration Shell entirely: a term in an ontology, with a definition
+// somebody published and a consumer can look up. A ModelReference — the type
+// already used above for "this shell has that submodel" — would say something
+// quite different.
+type Reference struct {
+	Type string `json:"type"`
+	Keys []Key  `json:"keys"`
+}
+
+// meaning builds the semantic identifier for one concept IRI.
+func meaning(iri string) *Reference {
+	if iri == "" {
+		return nil
+	}
+	return &Reference{
+		Type: "ExternalReference",
+		Keys: []Key{{Type: "GlobalReference", Value: iri}},
+	}
 }
 
 // ── SPARQL types ──────────────────────────────────────────────────────────────
@@ -117,6 +143,43 @@ type ServiceInfo struct {
 	ServiceDef  string // afo:hasServiceDefinition (optional)
 	URL         string // afo:hasUrl
 }
+
+// ── What the elements mean ────────────────────────────────────────────────────
+
+// The namespaces this bridge names concepts from.
+//
+// An Asset Administration Shell without semantic identifiers is a shape without
+// a meaning. A consumer receiving a property called "ServiceUrl_temperature" can
+// display the string and do nothing else with it: there is nothing to look up,
+// nothing to compare with a property from another vendor's shell, and no way to
+// tell a URL from a serial number except by reading the name and guessing. Every
+// element below therefore carries a semanticId naming the concept its value came
+// from.
+//
+// The identifiers are the ontology's own, because that is where these values
+// actually came from — democrat reads a knowledge graph, and each property is a
+// literal that was the object of one predicate. Pointing at that predicate is
+// both true and useful. Inventing an IDTA submodel template identifier instead
+// would claim conformance to a template this does not implement, which is worse
+// than claiming nothing.
+const (
+	// afo is the Arrowhead Framework Ontology, published with a DOI, which is
+	// what makes these identifiers worth dereferencing.
+	afo = "http://www.synecdoque.com/2025/afo#"
+	// alc is the local cloud's own namespace, for what this project mints.
+	alc = "http://www.synecdoque.com/lcloud/"
+)
+
+// Submodel templates. No IDTA template describes an Arrowhead system, so these
+// are the local cloud's own and are named as such. When a submodel here does
+// come to implement an IDTA template — an Asset Interfaces Description built
+// from these same endpoints is the obvious candidate — its identifier becomes
+// the IDTA one and this comment should shrink.
+const (
+	smtIdentity = alc + "aas/IdentitySubmodel"
+	smtHost     = alc + "aas/HostSubmodel"
+	smtServices = alc + "aas/ServicesSubmodel"
+)
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -375,12 +438,20 @@ func buildAASEnv(systems map[string]*SystemInfo) AASEnv {
 
 		// Identity submodel — static; does not need periodic patching.
 		env.Submodels = append(env.Submodels, Submodel{
-			ModelType: "Submodel",
-			ID:        smIdentity,
-			IDShort:   "Identity",
+			ModelType:  "Submodel",
+			ID:         smIdentity,
+			IDShort:    "Identity",
+			SemanticID: meaning(smtIdentity),
 			SubmodelElements: []SubmodelElement{
-				{ModelType: "Property", IDShort: "SystemName", ValueType: "xs:string", Value: s.SystemName},
-				{ModelType: "Property", IDShort: "SystemUri", ValueType: "xs:string", Value: s.SystemURI},
+				{ModelType: "Property", IDShort: "SystemName",
+					SemanticID: meaning(afo + "hasName"),
+					ValueType:  "xs:string", Value: s.SystemName},
+				{ModelType: "Property", IDShort: "SystemUri",
+					// The subject the graph knows this system by, which is what
+					// lets a consumer follow it back into the graph rather than
+					// treat this shell as the whole story.
+					SemanticID: meaning(afo + "System"),
+					ValueType:  "xs:anyURI", Value: s.SystemURI},
 			},
 		})
 
@@ -390,7 +461,8 @@ func buildAASEnv(systems map[string]*SystemInfo) AASEnv {
 			if s.HostName != "" {
 				elems = append(elems, SubmodelElement{
 					ModelType: "Property", IDShort: "HostName",
-					ValueType: "xs:string", Value: s.HostName,
+					SemanticID: meaning(afo + "hasName"),
+					ValueType:  "xs:string", Value: s.HostName,
 				})
 			}
 			for i, ip := range s.IPs {
@@ -399,13 +471,15 @@ func buildAASEnv(systems map[string]*SystemInfo) AASEnv {
 				}
 				elems = append(elems, SubmodelElement{
 					ModelType: "Property", IDShort: fmt.Sprintf("IP_%d", i+1),
-					ValueType: "xs:string", Value: ip,
+					SemanticID: meaning(afo + "hasIPAddress"),
+					ValueType:  "xs:string", Value: ip,
 				})
 			}
 			env.Submodels = append(env.Submodels, Submodel{
 				ModelType:        "Submodel",
 				ID:               smHost,
 				IDShort:          "Host",
+				SemanticID:       meaning(smtHost),
 				SubmodelElements: elems,
 			})
 		}
@@ -417,7 +491,8 @@ func buildAASEnv(systems map[string]*SystemInfo) AASEnv {
 			prop := "ServiceUrl_" + sanitizeIDShort(svc.ServiceName)
 			svcElems = append(svcElems, SubmodelElement{
 				ModelType: "Property", IDShort: prop,
-				ValueType: "xs:anyURI", Value: svc.URL,
+				SemanticID: meaning(afo + "hasUrl"),
+				ValueType:  "xs:anyURI", Value: svc.URL,
 			})
 		}
 		// Definition shortcuts (only when a definition maps to exactly one URL).
@@ -431,7 +506,10 @@ func buildAASEnv(systems map[string]*SystemInfo) AASEnv {
 			if len(urls) == 1 {
 				svcElems = append(svcElems, SubmodelElement{
 					ModelType: "Property", IDShort: titleCaseURL(def),
-					ValueType: "xs:anyURI", Value: urls[0],
+					// The shortcut is named for the service definition, so it
+					// means the definition rather than merely an address.
+					SemanticID: meaning(afo + "hasServiceDefinition"),
+					ValueType:  "xs:anyURI", Value: urls[0],
 				})
 			}
 		}
@@ -442,6 +520,7 @@ func buildAASEnv(systems map[string]*SystemInfo) AASEnv {
 			ModelType:        "Submodel",
 			ID:               smServices,
 			IDShort:          "Services",
+			SemanticID:       meaning(smtServices),
 			SubmodelElements: svcElems,
 		})
 	}

--- a/democrat/aas.go
+++ b/democrat/aas.go
@@ -44,9 +44,9 @@ import (
 // ── AAS data types (AAS Part 2 v3 JSON serialization) ─────────────────────────
 
 type AASEnv struct {
-	AssetAdministrationShells []AAS         `json:"assetAdministrationShells"`
-	Submodels                 []Submodel    `json:"submodels"`
-	ConceptDescriptions       []interface{} `json:"conceptDescriptions"`
+	AssetAdministrationShells []AAS                `json:"assetAdministrationShells"`
+	Submodels                 []Submodel           `json:"submodels"`
+	ConceptDescriptions       []ConceptDescription `json:"conceptDescriptions"`
 }
 
 type AAS struct {
@@ -479,7 +479,7 @@ func buildAASEnv(systems map[string]*SystemInfo) AASEnv {
 	env := AASEnv{
 		AssetAdministrationShells: []AAS{},
 		Submodels:                 []Submodel{},
-		ConceptDescriptions:       []interface{}{},
+		ConceptDescriptions:       []ConceptDescription{},
 	}
 
 	// Stable iteration order so output diffs are minimal.
@@ -639,82 +639,81 @@ func buildAASEnv(systems map[string]*SystemInfo) AASEnv {
 		}
 	}
 
+	// Last, because it reads what the loop above produced: every identifier the
+	// shell now mentions and this bridge is entitled to explain.
+	env.ConceptDescriptions = buildConceptDescriptions(env)
+
 	return env
 }
 
 // ── FA³ST upsert ──────────────────────────────────────────────────────────────
 
-// upsertShell creates or replaces an AAS in FA³ST.
-// It tries PUT (update) first; if FA³ST returns 404 it falls back to POST (create).
+// upsert creates or replaces one element in FA³ST.
+//
+// PUT first and POST on a 404, which is the only way to be sure without asking:
+// a GET to find out whether the element exists would be a second round trip and
+// would still be a guess by the time the write arrived.
+//
+// One function for shells, submodels and concept descriptions because the AAS
+// API treats them alike — collection, base64url identifier, same status codes.
+// Three copies of this existed in spirit; the third was the one that made it
+// obvious.
+func upsert(client *http.Client, faaastBase, collection, id string, payload any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal %s %s: %w", collection, id, err)
+	}
+	idB64 := b64url(id)
+
+	req, _ := http.NewRequest(http.MethodPut, faaastBase+"/"+collection+"/"+idB64, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("PUT /%s/%s: HTTP %d", collection, idB64, resp.StatusCode)
+	}
+
+	// It does not exist yet — create it.
+	req2, _ := http.NewRequest(http.MethodPost, faaastBase+"/"+collection, bytes.NewReader(body))
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, err := client.Do(req2)
+	if err != nil {
+		return err
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode == http.StatusCreated || resp2.StatusCode == http.StatusOK {
+		return nil
+	}
+	return fmt.Errorf("POST /%s: HTTP %d", collection, resp2.StatusCode)
+}
+
+// upsertShell creates or replaces an Asset Administration Shell.
 func upsertShell(client *http.Client, faaastBase string, aas AAS) error {
-	body, _ := json.Marshal(aas)
-	idB64 := b64url(aas.ID)
-	putURL := faaastBase + "/shells/" + idB64
-
-	req, _ := http.NewRequest(http.MethodPut, putURL, bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusOK {
-		return nil
-	}
-	if resp.StatusCode != http.StatusNotFound {
-		return fmt.Errorf("PUT /shells/%s: HTTP %d", idB64, resp.StatusCode)
-	}
-
-	// Shell does not exist yet — create it.
-	req2, _ := http.NewRequest(http.MethodPost, faaastBase+"/shells", bytes.NewReader(body))
-	req2.Header.Set("Content-Type", "application/json")
-	resp2, err := client.Do(req2)
-	if err != nil {
-		return err
-	}
-	resp2.Body.Close()
-	if resp2.StatusCode == http.StatusCreated || resp2.StatusCode == http.StatusOK {
-		return nil
-	}
-	return fmt.Errorf("POST /shells: HTTP %d", resp2.StatusCode)
+	return upsert(client, faaastBase, "shells", aas.ID, aas)
 }
 
-// upsertSubmodel creates or replaces a Submodel in FA³ST.
+// upsertSubmodel creates or replaces a submodel.
 func upsertSubmodel(client *http.Client, faaastBase string, sm Submodel) error {
-	body, _ := json.Marshal(sm)
-	idB64 := b64url(sm.ID)
-	putURL := faaastBase + "/submodels/" + idB64
-
-	req, _ := http.NewRequest(http.MethodPut, putURL, bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusOK {
-		return nil
-	}
-	if resp.StatusCode != http.StatusNotFound {
-		return fmt.Errorf("PUT /submodels/%s: HTTP %d", idB64, resp.StatusCode)
-	}
-
-	req2, _ := http.NewRequest(http.MethodPost, faaastBase+"/submodels", bytes.NewReader(body))
-	req2.Header.Set("Content-Type", "application/json")
-	resp2, err := client.Do(req2)
-	if err != nil {
-		return err
-	}
-	resp2.Body.Close()
-	if resp2.StatusCode == http.StatusCreated || resp2.StatusCode == http.StatusOK {
-		return nil
-	}
-	return fmt.Errorf("POST /submodels: HTTP %d", resp2.StatusCode)
+	return upsert(client, faaastBase, "submodels", sm.ID, sm)
 }
+
+// upsertConcept creates or replaces a concept description.
+//
+// Written before the submodels that point at it, so a consumer that reads the
+// shell between two syncs finds the meaning already there rather than a
+// semanticId leading nowhere.
+func upsertConcept(client *http.Client, faaastBase string, cd ConceptDescription) error {
+	return upsert(client, faaastBase, "concept-descriptions", cd.ID, cd)
+}
+
+// ── Small helpers ─────────────────────────────────────────────────────────────
 
 // appendOnce adds a value to a slice unless it is already there. The SPARQL
 // result multiplies rows across every OPTIONAL, so the same URL arrives once per

--- a/democrat/aas.go
+++ b/democrat/aas.go
@@ -84,8 +84,10 @@ type SubmodelElement struct {
 	ModelType  string     `json:"modelType"`
 	IDShort    string     `json:"idShort"`
 	SemanticID *Reference `json:"semanticId,omitempty"`
-	ValueType  string     `json:"valueType"`
-	Value      any        `json:"value,omitempty"`
+	// ValueType is absent on a collection or a reference element, which hold
+	// other elements rather than a typed literal.
+	ValueType string `json:"valueType,omitempty"`
+	Value     any    `json:"value,omitempty"`
 }
 
 // Reference points at the concept an element means, rather than at another
@@ -141,7 +143,30 @@ type SystemInfo struct {
 type ServiceInfo struct {
 	ServiceName string // afo:hasName
 	ServiceDef  string // afo:hasServiceDefinition (optional)
-	URL         string // afo:hasUrl
+	URL         string // afo:hasUrl — the first, kept for the Services submodel
+
+	// URLs is every address this service answers on, one per protocol the husk
+	// opens. A system listening on both http and https states two, and an
+	// interface description needs both: they are different endpoints with
+	// different security, not two spellings of one.
+	URLs []string
+
+	// Unit and QuantityKind are the QUDT IRIs the service registered, which is
+	// what turns a number into a measurement.
+	Unit         string
+	QuantityKind string
+
+	// Methods is what the service answers, as W3C HTTP method IRIs. Empty means
+	// the service never said, and a consumer assumes a read.
+	Methods []string
+
+	// Subscribable says a consumer may follow this value instead of asking for
+	// it repeatedly — which is exactly what WoT calls observable.
+	Subscribable bool
+
+	// Form is the payload form the service registered, e.g. "SignalA_v1a",
+	// which is how a number is told from a boolean.
+	Form string
 }
 
 // ── What the elements mean ────────────────────────────────────────────────────
@@ -334,8 +359,19 @@ WHERE {
 	}
 
 	// 3 — services (system → unitAsset → providesService → service)
+	//
+	// The service IRI is selected as well as its name, because a service that a
+	// husk serves over both http and https states one afo:hasUrl per protocol
+	// and so comes back as two rows. Grouping on the IRI collects them into one
+	// service with two addresses; grouping on the name would work today and
+	// break the day two unit assets in one system name a service alike.
+	//
+	// Unit, quantity kind, methods and subscribability are all optional: a
+	// service that measures nothing has no unit, and one that only answers GET
+	// says nothing about methods. Each is a separate OPTIONAL rather than one
+	// block, so a service missing any one of them still returns the others.
 	qSvc := sparqlPrefixes + `
-SELECT ?system ?svcName ?svcDef ?url
+SELECT ?system ?svc ?svcName ?svcDef ?url ?unit ?quantityKind ?method ?subscribable ?form
 FROM <` + currentGraph + `>
 WHERE {
   ?system a afo:System ;
@@ -344,26 +380,76 @@ WHERE {
   ?svc afo:hasName ?svcName ;
        afo:hasUrl ?url .
   OPTIONAL { ?svc afo:hasServiceDefinition ?svcDef . }
+  OPTIONAL { ?svc alc:hasUnit ?unit . }
+  OPTIONAL { ?svc alc:hasQuantityKind ?quantityKind . }
+  OPTIONAL { ?svc alc:hasMethods ?method . }
+  OPTIONAL { ?svc afo:isSubscribable ?subscribable . }
+  OPTIONAL { ?svc alc:hasForms ?form . }
 }
 `
 	r3, err := sparqlSelect(client, sparqlEndpoint, qSvc)
 	if err != nil {
 		return nil, fmt.Errorf("query services: %w", err)
 	}
+	// One row per combination of the optionals, so the same service arrives
+	// several times over: two URLs and two methods make four rows saying the
+	// same thing. Merging by IRI is what turns them back into one service.
+	byIRI := map[string]map[string]*ServiceInfo{}
 	for _, b := range r3.Results.Bindings {
 		s, ok := systems[b["system"].Value]
 		if !ok {
 			continue
 		}
-		svcDef := ""
-		if d, ok := b["svcDef"]; ok {
-			svcDef = d.Value
+		iri := b["svc"].Value
+		if byIRI[s.SystemURI] == nil {
+			byIRI[s.SystemURI] = map[string]*ServiceInfo{}
 		}
-		s.Services = append(s.Services, ServiceInfo{
-			ServiceName: b["svcName"].Value,
-			ServiceDef:  svcDef,
-			URL:         b["url"].Value,
-		})
+		svc, seen := byIRI[s.SystemURI][iri]
+		if !seen {
+			svc = &ServiceInfo{ServiceName: b["svcName"].Value}
+			byIRI[s.SystemURI][iri] = svc
+			s.Services = append(s.Services, ServiceInfo{})
+		}
+		if d, ok := b["svcDef"]; ok {
+			svc.ServiceDef = d.Value
+		}
+		if u, ok := b["url"]; ok {
+			svc.URLs = appendOnce(svc.URLs, u.Value)
+		}
+		if u, ok := b["unit"]; ok {
+			svc.Unit = u.Value
+		}
+		if q, ok := b["quantityKind"]; ok {
+			svc.QuantityKind = q.Value
+		}
+		if m, ok := b["method"]; ok {
+			svc.Methods = appendOnce(svc.Methods, m.Value)
+		}
+		if sub, ok := b["subscribable"]; ok {
+			svc.Subscribable = sub.Value == "true"
+		}
+		if f, ok := b["form"]; ok {
+			svc.Form = localName(f.Value)
+		}
+	}
+	// Replace the placeholders with the merged services, in a stable order.
+	for uri, svcs := range byIRI {
+		s := systems[uri]
+		iris := make([]string, 0, len(svcs))
+		for iri := range svcs {
+			iris = append(iris, iri)
+		}
+		sort.Strings(iris)
+		s.Services = s.Services[:0]
+		for _, iri := range iris {
+			svc := svcs[iri]
+			sort.Strings(svc.URLs)
+			sort.Strings(svc.Methods)
+			if len(svc.URLs) > 0 {
+				svc.URL = svc.URLs[0]
+			}
+			s.Services = append(s.Services, *svc)
+		}
 	}
 
 	// Deduplicate and sort IP addresses for stable output.
@@ -411,6 +497,7 @@ func buildAASEnv(systems map[string]*SystemInfo) AASEnv {
 		smIdentity := "urn:alc:sm:" + idShort + ":Identity"
 		smHost := "urn:alc:sm:" + idShort + ":Host"
 		smServices := "urn:alc:sm:" + idShort + ":Services"
+		smInterfaces := "urn:alc:sm:" + idShort + ":AssetInterfacesDescription"
 
 		// Build submodel references for the AAS header.
 		refs := []ModelReference{
@@ -494,6 +581,21 @@ func buildAASEnv(systems map[string]*SystemInfo) AASEnv {
 				SemanticID: meaning(afo + "hasUrl"),
 				ValueType:  "xs:anyURI", Value: svc.URL,
 			})
+			// What the Asset Interfaces Description cannot say. AID 1.0 gives a
+			// property one form and one method name, so a setpoint that answers
+			// both GET and PUT states only the read there. Here there is room
+			// for the whole list, and a shell that mentions the write in one
+			// place is better than one that mentions it nowhere.
+			if len(svc.Methods) > 1 {
+				svcElems = append(svcElems, SubmodelElement{
+					ModelType: "Property",
+					IDShort:   "Methods_" + sanitizeIDShort(svc.ServiceName),
+					// Local, because afo: does not define it yet; the framework
+					// writes it as alc:hasMethods for the same reason.
+					SemanticID: meaning(alc + "hasMethods"),
+					ValueType:  "xs:string", Value: strings.Join(methodNames(svc.Methods), " "),
+				})
+			}
 		}
 		// Definition shortcuts (only when a definition maps to exactly one URL).
 		defMap := map[string][]string{}
@@ -523,6 +625,18 @@ func buildAASEnv(systems map[string]*SystemInfo) AASEnv {
 			SemanticID:       meaning(smtServices),
 			SubmodelElements: svcElems,
 		})
+
+		// Asset Interfaces Description — the one submodel here that implements
+		// a published IDTA template rather than a local convention, and the one
+		// a consumer outside this cloud has tooling for.
+		if aid, ok := buildAID(s, smInterfaces); ok {
+			env.Submodels = append(env.Submodels, aid)
+			env.AssetAdministrationShells[len(env.AssetAdministrationShells)-1].Submodels = append(
+				env.AssetAdministrationShells[len(env.AssetAdministrationShells)-1].Submodels,
+				ModelReference{Type: "ModelReference",
+					Keys: []Key{{Type: "Submodel", Value: smInterfaces}}},
+			)
+		}
 	}
 
 	return env
@@ -600,4 +714,38 @@ func upsertSubmodel(client *http.Client, faaastBase string, sm Submodel) error {
 		return nil
 	}
 	return fmt.Errorf("POST /submodels: HTTP %d", resp2.StatusCode)
+}
+
+// appendOnce adds a value to a slice unless it is already there. The SPARQL
+// result multiplies rows across every OPTIONAL, so the same URL arrives once per
+// method and the same method once per URL.
+func appendOnce(list []string, value string) []string {
+	for _, existing := range list {
+		if existing == value {
+			return list
+		}
+	}
+	return append(list, value)
+}
+
+// localName is the last segment of an IRI, and the value itself when it is not
+// one. A detail whose value is a legal name reaches the graph as an entity in
+// the local cloud's namespace — alc:SignalA_v1a — while one with a slash in it
+// stays a literal, so both shapes come back from the same query.
+func localName(value string) string {
+	if i := strings.LastIndexAny(value, "#/"); i >= 0 && i+1 < len(value) {
+		return value[i+1:]
+	}
+	return value
+}
+
+// methodNames turns W3C HTTP method IRIs back into the names a reader expects,
+// for a value that is meant to be read by a person as well as a machine.
+func methodNames(methods []string) []string {
+	out := make([]string, 0, len(methods))
+	for _, m := range methods {
+		out = append(out, localName(m))
+	}
+	sort.Strings(out)
+	return out
 }

--- a/democrat/aid.go
+++ b/democrat/aid.go
@@ -1,0 +1,381 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Synecdoque
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, subject to the following conditions:
+ *
+ * The software is licensed under the MIT License. See the LICENSE file in this repository for details.
+ *
+ * Contributors:
+ *   Jan A. van Deventer, Luleå - initial implementation
+ *   Thomas Hedeler, Hamburg - initial implementation
+ ***************************************************************************SDG*/
+
+// The Asset Interfaces Description: how to talk to a system, in the vocabulary
+// the rest of the world uses for that.
+//
+// The other three submodels this bridge writes are the local cloud's own, and
+// say so. This one is not: IDTA 02017-1-0 is a published template built on the
+// W3C Web of Things Thing Description, and an Arrowhead service registration
+// happens to hold nearly everything it asks for. That is worth taking seriously
+// rather than paraphrasing — a consumer that has never heard of Arrowhead can
+// read this submodel with tooling it already has.
+//
+// Three of the mappings are exact rather than approximate:
+//
+//	observable      ← afo:isSubscribable   a value you may follow, not poll
+//	unit            ← the QUDT unit IRI    schema.org/unitCode admits a URL
+//	valueSemantics  ← the QUDT quantity kind, which is what that slot is for
+//
+// so this is the first submodel here entitled to an admin-shell.io semanticId.
+// It carries them because it implements the template, not because they look
+// more official than a local identifier.
+package main
+
+import (
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// The identifiers IDTA 02017-1-0 defines, copied from the published template
+// rather than reconstructed, because they are what a consumer matches on.
+//
+// aidPropertyDefinition really does say "AssetInterfaceDescription" while every
+// other identifier says "AssetInterfacesDescription". That inconsistency is in
+// the published template; correcting it here would mint an identifier nobody
+// else uses, which is the opposite of the point.
+const (
+	aidSubmodel            = "https://admin-shell.io/idta/AssetInterfacesDescription/1/0/Submodel"
+	aidInterface           = "https://admin-shell.io/idta/AssetInterfacesDescription/1/0/Interface"
+	aidEndpointMetadata    = "https://admin-shell.io/idta/AssetInterfacesDescription/1/0/EndpointMetadata"
+	aidInteractionMetadata = "https://admin-shell.io/idta/AssetInterfacesDescription/1/0/InteractionMetadata"
+	aidPropertyDefinition  = "https://admin-shell.io/idta/AssetInterfaceDescription/1/0/PropertyDefinition"
+	aidKey                 = "https://admin-shell.io/idta/AssetInterfacesDescription/1/0/key"
+	aidValueSemantics      = "https://admin-shell.io/idta/AssetInterfacesDescription/1/0/valueSemantics"
+)
+
+// The Web of Things vocabulary the template borrows, which is where the
+// interesting terms actually live.
+const (
+	wotTitle                 = "https://www.w3.org/2019/wot/td#title"
+	wotBaseURI               = "https://www.w3.org/2019/wot/td#baseURI"
+	wotHasForm               = "https://www.w3.org/2019/wot/td#hasForm"
+	wotPropertyAffordance    = "https://www.w3.org/2019/wot/td#PropertyAffordance"
+	wotIsObservable          = "https://www.w3.org/2019/wot/td#isObservable"
+	wotDefinesSecurityScheme = "https://www.w3.org/2019/wot/td#definesSecurityScheme"
+	wotNoSecurityScheme      = "https://www.w3.org/2019/wot/security#NoSecurityScheme"
+	wotAutoSecurityScheme    = "https://www.w3.org/2019/wot/security#AutoSecurityScheme"
+	wotForContentType        = "https://www.w3.org/2019/wot/hypermedia#forContentType"
+	wotHasTarget             = "https://www.w3.org/2019/wot/hypermedia#hasTarget"
+	rdfType                  = "https://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+	schemaUnitCode           = "https://schema.org/unitCode"
+	htvMethodName            = "https://www.w3.org/2011/http#methodName"
+)
+
+// buildAID returns the Asset Interfaces Description for one system, and whether
+// there was anything to describe.
+//
+// One interface per protocol the husk opens, because http and https are not two
+// spellings of one endpoint: they have different addresses and, more to the
+// point, different security. A system that offers both gets two interfaces, and
+// a consumer picks the one it can use.
+func buildAID(s *SystemInfo, submodelID string) (Submodel, bool) {
+	byScheme := map[string][]ServiceInfo{}
+	baseOf := map[string]string{}
+
+	for _, svc := range s.Services {
+		for _, raw := range addressesOf(svc) {
+			parsed, err := url.Parse(raw)
+			if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+				continue
+			}
+			base := parsed.Scheme + "://" + parsed.Host + "/" + s.SystemName + "/"
+			byScheme[parsed.Scheme] = append(byScheme[parsed.Scheme], svc)
+			baseOf[parsed.Scheme] = base
+		}
+	}
+	if len(byScheme) == 0 {
+		return Submodel{}, false
+	}
+
+	schemes := make([]string, 0, len(byScheme))
+	for scheme := range byScheme {
+		schemes = append(schemes, scheme)
+	}
+	sort.Strings(schemes)
+
+	interfaces := make([]SubmodelElement, 0, len(schemes))
+	for _, scheme := range schemes {
+		interfaces = append(interfaces, oneInterface(s, scheme, baseOf[scheme], byScheme[scheme]))
+	}
+
+	return Submodel{
+		ModelType:        "Submodel",
+		ID:               submodelID,
+		IDShort:          "AssetInterfacesDescription",
+		SemanticID:       meaning(aidSubmodel),
+		SubmodelElements: interfaces,
+	}, true
+}
+
+// oneInterface describes how to reach this system over one protocol.
+func oneInterface(s *SystemInfo, scheme, base string, services []ServiceInfo) SubmodelElement {
+	return SubmodelElement{
+		ModelType:  "SubmodelElementCollection",
+		IDShort:    "Interface" + strings.ToUpper(scheme),
+		SemanticID: meaning(aidInterface),
+		Value: []SubmodelElement{
+			{ModelType: "Property", IDShort: "title",
+				SemanticID: meaning(wotTitle),
+				ValueType:  "xs:string", Value: s.SystemName},
+			endpointMetadata(scheme, base),
+			interactionMetadata(base, services),
+		},
+	}
+}
+
+// endpointMetadata says where the system is and how a consumer gets in.
+//
+// The security scheme is the one place where the Web of Things vocabulary has
+// no name for what mbaigo actually does. Its schemes are nosec, basic, digest,
+// bearer, psk, apikey, oauth2, combo and auto; none of them is "mutual TLS with
+// a cloud certificate authority, plus a per-action token from the authorizer".
+//
+// So: plain http says nosec_sc, which is true — that port is unauthenticated.
+// https says auto_sc, the Web of Things term for security arranged out of band,
+// which is honest about being underspecified. Claiming bearer_sc would describe
+// the token and quietly drop the certificate, and the certificate is the half
+// that decides whether a connection happens at all.
+func endpointMetadata(scheme, base string) SubmodelElement {
+	schemeName, schemeMeaning := "nosec_sc", wotNoSecurityScheme
+	if scheme != "http" {
+		schemeName, schemeMeaning = "auto_sc", wotAutoSecurityScheme
+	}
+
+	return SubmodelElement{
+		ModelType:  "SubmodelElementCollection",
+		IDShort:    "EndpointMetadata",
+		SemanticID: meaning(aidEndpointMetadata),
+		Value: []SubmodelElement{
+			{ModelType: "Property", IDShort: "base",
+				SemanticID: meaning(wotBaseURI),
+				ValueType:  "xs:anyURI", Value: base},
+			{ModelType: "Property", IDShort: "contentType",
+				SemanticID: meaning(wotForContentType),
+				ValueType:  "xs:string", Value: "application/json"},
+			{ModelType: "SubmodelElementCollection",
+				IDShort:    "securityDefinitions",
+				SemanticID: meaning(wotDefinesSecurityScheme),
+				Value: []SubmodelElement{{
+					ModelType:  "SubmodelElementCollection",
+					IDShort:    schemeName,
+					SemanticID: meaning(schemeMeaning),
+					Value:      []SubmodelElement{},
+				}},
+			},
+		},
+	}
+}
+
+// interactionMetadata turns the system's services into property affordances.
+func interactionMetadata(base string, services []ServiceInfo) SubmodelElement {
+	seen := map[string]bool{}
+	props := []SubmodelElement{}
+	for _, svc := range services {
+		idShort := sanitizeIDShort(svc.ServiceName)
+		if seen[idShort] {
+			continue
+		}
+		seen[idShort] = true
+		props = append(props, propertyDefinition(base, svc, idShort))
+	}
+	sort.Slice(props, func(i, j int) bool { return props[i].IDShort < props[j].IDShort })
+
+	return SubmodelElement{
+		ModelType:  "SubmodelElementCollection",
+		IDShort:    "InteractionMetadata",
+		SemanticID: meaning(aidInteractionMetadata),
+		Value: []SubmodelElement{{
+			ModelType:  "SubmodelElementCollection",
+			IDShort:    "properties",
+			SemanticID: meaning(wotPropertyAffordance),
+			Value:      props,
+		}},
+	}
+}
+
+// propertyDefinition describes one service as something a consumer can read.
+func propertyDefinition(base string, svc ServiceInfo, idShort string) SubmodelElement {
+	key := svc.ServiceDef
+	if key == "" {
+		key = svc.ServiceName
+	}
+
+	elems := []SubmodelElement{
+		{ModelType: "Property", IDShort: "key",
+			SemanticID: meaning(aidKey),
+			ValueType:  "xs:string", Value: key},
+		{ModelType: "Property", IDShort: "type",
+			SemanticID: meaning(rdfType),
+			ValueType:  "xs:string", Value: jsonTypeOf(svc)},
+		{ModelType: "Property", IDShort: "title",
+			SemanticID: meaning(wotTitle),
+			ValueType:  "xs:string", Value: svc.ServiceName},
+		// The framework's own word for it. A subscribable service is one a
+		// consumer may follow instead of asking again, which is what the Web of
+		// Things means by observable — the same idea, arrived at separately.
+		{ModelType: "Property", IDShort: "observable",
+			SemanticID: meaning(wotIsObservable),
+			ValueType:  "xs:boolean", Value: svc.Subscribable},
+	}
+
+	// schema.org/unitCode takes a UN/CEFACT code or a URL, so the QUDT IRI goes
+	// in as it stands rather than being translated into a three-letter code
+	// that would lose the conversion factors behind it.
+	if svc.Unit != "" {
+		elems = append(elems, SubmodelElement{
+			ModelType: "Property", IDShort: "unit",
+			SemanticID: meaning(schemaUnitCode),
+			ValueType:  "xs:string", Value: svc.Unit,
+		})
+	}
+	// valueSemantics is a reference element because what it points at is a
+	// concept elsewhere — here the QUDT quantity kind, which says a number is a
+	// temperature rather than merely a number with °C after it.
+	if svc.QuantityKind != "" {
+		elems = append(elems, SubmodelElement{
+			ModelType: "ReferenceElement", IDShort: "valueSemantics",
+			SemanticID: meaning(aidValueSemantics),
+			Value:      externalReference(svc.QuantityKind),
+		})
+	}
+
+	elems = append(elems, forms(base, svc))
+
+	return SubmodelElement{
+		ModelType:  "SubmodelElementCollection",
+		IDShort:    idShort,
+		SemanticID: meaning(aidPropertyDefinition),
+		Value:      elems,
+	}
+}
+
+// forms says how to reach this one service.
+//
+// AID 1.0 gives a property exactly one form and that form one htv_methodName,
+// so a service answering both GET and PUT cannot state both here. This emits
+// the method a consumer reads with, or the sole method when the service does
+// not read at all — beehive's toggle is a PUT and the certificate authority's
+// certify is a POST, and calling either of those a GET would be worse than
+// saying nothing.
+//
+// What the template cannot hold is not thrown away: the Services submodel
+// carries the complete method list against alc:hasMethods. A consumer reading
+// only the AID sees how to read the value, and one reading the whole shell sees
+// that the setpoint can also be written.
+func forms(base string, svc ServiceInfo) SubmodelElement {
+	elems := []SubmodelElement{
+		{ModelType: "Property", IDShort: "href",
+			SemanticID: meaning(wotHasTarget),
+			ValueType:  "xs:string", Value: hrefFor(base, svc)},
+		{ModelType: "Property", IDShort: "contentType",
+			SemanticID: meaning(wotForContentType),
+			ValueType:  "xs:string", Value: "application/json"},
+	}
+	if method := readMethod(svc.Methods); method != "" {
+		elems = append(elems, SubmodelElement{
+			ModelType: "Property", IDShort: "htv_methodName",
+			SemanticID: meaning(htvMethodName),
+			ValueType:  "xs:string", Value: method,
+		})
+	}
+
+	return SubmodelElement{
+		ModelType:  "SubmodelElementCollection",
+		IDShort:    "forms",
+		SemanticID: meaning(wotHasForm),
+		Value:      elems,
+	}
+}
+
+// readMethod picks the method a consumer would use to read a value: GET when
+// the service offers it, the only method when it offers one, and nothing when
+// the service never said — where a consumer assumes GET anyway, so stating it
+// would add a claim rather than a fact.
+func readMethod(methods []string) string {
+	names := make([]string, 0, len(methods))
+	for _, m := range methods {
+		names = append(names, localName(m))
+	}
+	for _, name := range names {
+		if name == "GET" {
+			return "GET"
+		}
+	}
+	if len(names) == 1 {
+		return names[0]
+	}
+	sort.Strings(names)
+	if len(names) > 0 {
+		return names[0]
+	}
+	return ""
+}
+
+// addressesOf is every address a service answers on. A service that came from
+// the graph has them all; one built by hand, or from a registration that stated
+// a single URL, has the one.
+func addressesOf(svc ServiceInfo) []string {
+	if len(svc.URLs) > 0 {
+		return svc.URLs
+	}
+	if svc.URL != "" {
+		return []string{svc.URL}
+	}
+	return nil
+}
+
+// hrefFor returns the service address relative to the interface's base, which
+// is what a form holds: the base is stated once for the whole interface, and
+// repeating it per property would be a second place for the host to be wrong.
+func hrefFor(base string, svc ServiceInfo) string {
+	for _, raw := range addressesOf(svc) {
+		if strings.HasPrefix(raw, base) {
+			return strings.TrimPrefix(raw, base)
+		}
+	}
+	// No URL under this base: fall back to the absolute address, which a form
+	// is allowed to hold and which is at least reachable.
+	if svc.URL != "" {
+		return svc.URL
+	}
+	return ""
+}
+
+// jsonTypeOf reports the JSON type of a service's value, from the payload form
+// it registered. SignalB carries a boolean and SignalA a number; anything else
+// is described as a string, which is what an unparsed body is.
+func jsonTypeOf(svc ServiceInfo) string {
+	switch {
+	case strings.HasPrefix(svc.Form, "SignalB"):
+		return "boolean"
+	case strings.HasPrefix(svc.Form, "SignalA"):
+		return "number"
+	case svc.Unit != "" || svc.QuantityKind != "":
+		// It measures something, so it is a number even if the form did not
+		// reach the graph.
+		return "number"
+	default:
+		return "string"
+	}
+}
+
+// externalReference is the value of a reference element pointing outside the
+// shell, which is the same shape meaning() builds for a semanticId.
+func externalReference(iri string) *Reference {
+	return meaning(iri)
+}

--- a/democrat/aid_test.go
+++ b/democrat/aid_test.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// find returns the element at a slash-separated path of idShorts, or nil.
+func find(elems []SubmodelElement, path string) *SubmodelElement {
+	parts := strings.Split(path, "/")
+	for i := range elems {
+		if elems[i].IDShort != parts[0] {
+			continue
+		}
+		if len(parts) == 1 {
+			return &elems[i]
+		}
+		kids, ok := elems[i].Value.([]SubmodelElement)
+		if !ok {
+			return nil
+		}
+		return find(kids, strings.Join(parts[1:], "/"))
+	}
+	return nil
+}
+
+func aidOf(t *testing.T, s *SystemInfo) Submodel {
+	t.Helper()
+	env := buildAASEnv(map[string]*SystemInfo{s.SystemURI: s})
+	for _, sm := range env.Submodels {
+		if sm.IDShort == "AssetInterfacesDescription" {
+			return sm
+		}
+	}
+	t.Fatal("no Asset Interfaces Description was built")
+	return Submodel{}
+}
+
+func thermostat() *SystemInfo {
+	return &SystemInfo{
+		SystemURI: "alc:thermostat", SystemName: "thermostat",
+		HostName: "pi-office", IPs: []string{"192.168.1.10"},
+		Services: []ServiceInfo{{
+			ServiceName: "controller/setpoint", ServiceDef: "setpoint",
+			URLs: []string{
+				"http://192.168.1.10:20185/thermostat/controller/setpoint",
+				"https://192.168.1.10:30185/thermostat/controller/setpoint",
+			},
+			URL:          "http://192.168.1.10:20185/thermostat/controller/setpoint",
+			Unit:         "http://qudt.org/vocab/unit/DEG_C",
+			QuantityKind: "http://qudt.org/vocab/quantitykind/ThermodynamicTemperature",
+			Methods: []string{
+				"http://www.w3.org/2011/http-methods#GET",
+				"http://www.w3.org/2011/http-methods#PUT",
+			},
+			Subscribable: true, Form: "SignalA_v1a",
+		}},
+	}
+}
+
+// A husk that opens two ports is reachable two ways, and the two are not
+// interchangeable: one is unauthenticated and the other is not. Describing them
+// as one interface would leave a consumer to guess which security applies.
+func TestOneInterfacePerProtocol(t *testing.T) {
+	aid := aidOf(t, thermostat())
+
+	if len(aid.SubmodelElements) != 2 {
+		t.Fatalf("got %d interfaces, want one per protocol", len(aid.SubmodelElements))
+	}
+	for _, want := range []struct{ iface, base, security string }{
+		{"InterfaceHTTP", "http://192.168.1.10:20185/thermostat/", "nosec_sc"},
+		{"InterfaceHTTPS", "https://192.168.1.10:30185/thermostat/", "auto_sc"},
+	} {
+		base := find(aid.SubmodelElements, want.iface+"/EndpointMetadata/base")
+		if base == nil {
+			t.Errorf("%s has no base", want.iface)
+			continue
+		}
+		if base.Value != want.base {
+			t.Errorf("%s base = %v, want %q", want.iface, base.Value, want.base)
+		}
+		if find(aid.SubmodelElements, want.iface+"/EndpointMetadata/securityDefinitions/"+want.security) == nil {
+			t.Errorf("%s does not declare %s", want.iface, want.security)
+		}
+	}
+}
+
+// The three mappings that are exact rather than approximate. If any of them
+// drifts, this submodel goes back to being a shape with a name on it.
+func TestTheExactMappings(t *testing.T) {
+	aid := aidOf(t, thermostat())
+	const prop = "InterfaceHTTPS/InteractionMetadata/properties/controller_setpoint"
+
+	// A subscribable service is one a consumer may follow rather than poll,
+	// which is what the Web of Things means by observable.
+	if el := find(aid.SubmodelElements, prop+"/observable"); el == nil || el.Value != true {
+		t.Errorf("observable = %v, want the service's subscribability", el)
+	}
+	// schema.org/unitCode admits a URL, so the QUDT IRI goes in whole and keeps
+	// the conversion factors behind it.
+	if el := find(aid.SubmodelElements, prop+"/unit"); el == nil ||
+		el.Value != "http://qudt.org/vocab/unit/DEG_C" {
+		t.Errorf("unit = %v, want the QUDT unit IRI", el)
+	}
+	// valueSemantics exists to point at what the value means, and a quantity
+	// kind is precisely that: this is a temperature, not a number with °C after it.
+	el := find(aid.SubmodelElements, prop+"/valueSemantics")
+	if el == nil {
+		t.Fatal("no valueSemantics")
+	}
+	if el.ModelType != "ReferenceElement" {
+		t.Errorf("valueSemantics is a %s; a concept elsewhere needs a reference", el.ModelType)
+	}
+	ref, ok := el.Value.(*Reference)
+	if !ok || len(ref.Keys) != 1 ||
+		ref.Keys[0].Value != "http://qudt.org/vocab/quantitykind/ThermodynamicTemperature" {
+		t.Errorf("valueSemantics = %v, want the QUDT quantity kind", el.Value)
+	}
+}
+
+// A form's href is relative to the interface's base. Repeating the host in every
+// property would be a second place for it to be wrong, and it is the part that
+// changes when a system moves.
+func TestHrefIsRelativeToTheBase(t *testing.T) {
+	aid := aidOf(t, thermostat())
+	el := find(aid.SubmodelElements,
+		"InterfaceHTTP/InteractionMetadata/properties/controller_setpoint/forms/href")
+	if el == nil {
+		t.Fatal("no href")
+	}
+	if el.Value != "controller/setpoint" {
+		t.Errorf("href = %v, want it relative to the base", el.Value)
+	}
+}
+
+// AID 1.0 gives a property one form and that form one method name, so a service
+// answering GET and PUT can only state the read here. What it cannot state must
+// still appear somewhere: the Services submodel carries the whole list.
+func TestAWriteIsNotSilentlyDropped(t *testing.T) {
+	s := thermostat()
+	env := buildAASEnv(map[string]*SystemInfo{s.SystemURI: s})
+
+	var aid, services Submodel
+	for _, sm := range env.Submodels {
+		switch sm.IDShort {
+		case "AssetInterfacesDescription":
+			aid = sm
+		case "Services":
+			services = sm
+		}
+	}
+
+	method := find(aid.SubmodelElements,
+		"InterfaceHTTPS/InteractionMetadata/properties/controller_setpoint/forms/htv_methodName")
+	if method == nil || method.Value != "GET" {
+		t.Errorf("htv_methodName = %v, want the method a consumer reads with", method)
+	}
+
+	el := find(services.SubmodelElements, "Methods_controller_setpoint")
+	if el == nil {
+		t.Fatal("the Services submodel does not say the setpoint can be written")
+	}
+	if el.Value != "GET PUT" {
+		t.Errorf("Methods = %v, want the complete list", el.Value)
+	}
+	if el.SemanticID == nil || el.SemanticID.Keys[0].Value != alc+"hasMethods" {
+		t.Errorf("the method list means %v, want the predicate the graph used", el.SemanticID)
+	}
+}
+
+// A service that never reads states the method it does answer. Calling beehive's
+// toggle a GET would be worse than saying nothing, because a consumer would
+// believe it.
+func TestAServiceThatOnlyWritesSaysSo(t *testing.T) {
+	aid := aidOf(t, &SystemInfo{
+		SystemURI: "alc:beehive", SystemName: "beehive",
+		Services: []ServiceInfo{{
+			ServiceName: "hive/toggle", ServiceDef: "Toggle",
+			URLs:    []string{"http://192.168.1.10:20190/beehive/hive/toggle"},
+			Methods: []string{"http://www.w3.org/2011/http-methods#PUT"},
+			Form:    "SignalB_v1a",
+		}},
+	})
+
+	el := find(aid.SubmodelElements,
+		"InterfaceHTTP/InteractionMetadata/properties/hive_toggle/forms/htv_methodName")
+	if el == nil || el.Value != "PUT" {
+		t.Errorf("htv_methodName = %v, want PUT", el)
+	}
+	// And a SignalB carries a boolean, not a number.
+	if el := find(aid.SubmodelElements,
+		"InterfaceHTTP/InteractionMetadata/properties/hive_toggle/type"); el == nil ||
+		el.Value != "boolean" {
+		t.Errorf("type = %v, want boolean", el)
+	}
+}
+
+// A service that said nothing about methods gets no claim made on its behalf.
+// A consumer assumes a read of a service it has been told nothing about, so
+// stating GET would add a claim rather than a fact.
+func TestSilenceAboutMethodsStaysSilent(t *testing.T) {
+	aid := aidOf(t, &SystemInfo{
+		SystemURI: "alc:ds18b20", SystemName: "ds18b20",
+		Services: []ServiceInfo{{
+			ServiceName: "probe/temperature", ServiceDef: "temperature",
+			URLs: []string{"http://192.168.1.10:20150/ds18b20/probe/temperature"},
+		}},
+	})
+	if el := find(aid.SubmodelElements,
+		"InterfaceHTTP/InteractionMetadata/properties/probe_temperature/forms/htv_methodName"); el != nil {
+		t.Errorf("htv_methodName = %v; the service never said", el.Value)
+	}
+}
+
+// A system whose services have no address has no interface to describe, and an
+// empty interface description is worse than none: it says the system was looked
+// at and found to offer nothing.
+func TestNoAddressNoInterfaceDescription(t *testing.T) {
+	env := buildAASEnv(map[string]*SystemInfo{
+		"alc:ghost": {SystemURI: "alc:ghost", SystemName: "ghost"},
+	})
+	for _, sm := range env.Submodels {
+		if sm.IDShort == "AssetInterfacesDescription" {
+			t.Error("a system with no addresses was given an interface description")
+		}
+	}
+	for _, ref := range env.AssetAdministrationShells[0].Submodels {
+		if strings.Contains(ref.Keys[0].Value, "AssetInterfacesDescription") {
+			t.Error("the shell references an interface description that was not built")
+		}
+	}
+}

--- a/democrat/concepts.go
+++ b/democrat/concepts.go
@@ -1,0 +1,259 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Synecdoque
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, subject to the following conditions:
+ *
+ * The software is licensed under the MIT License. See the LICENSE file in this repository for details.
+ *
+ * Contributors:
+ *   Jan A. van Deventer, Luleå - initial implementation
+ *   Thomas Hedeler, Hamburg - initial implementation
+ ***************************************************************************SDG*/
+
+// Concept descriptions: what the identifiers scattered through this shell mean,
+// for a reader who cannot fetch them.
+//
+// A semanticId is a promise that somebody, somewhere, has written down what the
+// identifier stands for. A concept description is that writing-down brought
+// inside the environment, so a consumer with no internet — or no interest in
+// dereferencing an IRI it has never seen — can still learn that a value is a
+// temperature in degrees Celsius.
+//
+// The rule for what gets one is: describe what only we can describe.
+//
+//   - The local cloud's own identifiers get a description, because nothing else
+//     in the world defines them. If democrat does not say what
+//     alc:aas/ServicesSubmodel means, nobody can.
+//   - QUDT units and quantity kinds get one, not to redefine QUDT — which is
+//     authoritative and dereferences — but to carry the IEC 61360 translation
+//     the Asset Administration Shell world actually reads: the symbol °C beside
+//     a unitId pointing at the QUDT IRI. QUDT does not publish that pairing;
+//     this bridge is the only place it can be made.
+//   - AFO terms get none. The Arrowhead Framework Ontology is published with a
+//     DOI and defines its own terms properly. Restating those definitions inside
+//     every shell would be the same duplication democrat exists to remove, and
+//     the copies would drift the first time the ontology was revised.
+//   - IDTA and Web of Things identifiers get none either, for the same reason
+//     and with less claim: they are not ours to define.
+package main
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/sdoque/mbaigo/usecases"
+)
+
+// iec61360 is the data specification template that gives a concept description
+// its content. The Asset Administration Shell has one shape for saying "this is
+// a real measure whose unit is °C", and this is it.
+const iec61360 = "https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0"
+
+// The QUDT namespaces, matched on rather than parsed, so a value that merely
+// looks like an IRI is not mistaken for a unit.
+const (
+	qudtUnit = "http://qudt.org/vocab/unit/"
+	qudtKind = "http://qudt.org/vocab/quantitykind/"
+)
+
+// ConceptDescription is one identifier explained.
+type ConceptDescription struct {
+	ModelType                  string                      `json:"modelType"`
+	ID                         string                      `json:"id"`
+	IDShort                    string                      `json:"idShort"`
+	EmbeddedDataSpecifications []EmbeddedDataSpecification `json:"embeddedDataSpecifications,omitempty"`
+}
+
+// EmbeddedDataSpecification pairs a template with content shaped by it.
+type EmbeddedDataSpecification struct {
+	DataSpecification        Reference       `json:"dataSpecification"`
+	DataSpecificationContent Iec61360Content `json:"dataSpecificationContent"`
+}
+
+// Iec61360Content is the subset of IEC 61360 this bridge can fill honestly.
+// The specification allows a good deal more — value lists, level types, source
+// of definition — and a field left empty says more than one filled with a guess.
+type Iec61360Content struct {
+	ModelType     string     `json:"modelType"`
+	PreferredName []LangText `json:"preferredName"`
+	ShortName     []LangText `json:"shortName,omitempty"`
+	Unit          string     `json:"unit,omitempty"`
+	UnitID        *Reference `json:"unitId,omitempty"`
+	DataType      string     `json:"dataType,omitempty"`
+	Definition    []LangText `json:"definition,omitempty"`
+}
+
+// LangText is a string that knows what language it is in.
+type LangText struct {
+	Language string `json:"language"`
+	Text     string `json:"text"`
+}
+
+// en tags a string as English, which is what every definition here is written
+// in and what a consumer should be told rather than left to assume.
+func en(text string) []LangText {
+	return []LangText{{Language: "en", Text: text}}
+}
+
+// What the local cloud's own identifiers mean. These are the definitions, not
+// copies of definitions: no ontology holds them, so this is where they live.
+var localConcepts = map[string]string{
+	smtIdentity: "The identity of an Arrowhead system: the name it registered under and " +
+		"the URI the local cloud's knowledge graph knows it by.",
+	smtHost: "The machine an Arrowhead system runs on, as its husk reports it: the host " +
+		"name and every address it answers on.",
+	smtServices: "The services an Arrowhead system offers, each as the address it is " +
+		"reachable at, together with the methods it answers.",
+	alc + "hasMethods": "The HTTP methods a service answers, as W3C HTTP method IRIs. " +
+		"A service that says nothing answers a read.",
+}
+
+// buildConceptDescriptions explains every identifier in the environment that
+// this bridge is entitled to explain.
+//
+// It walks what was built rather than being handed a list, so a submodel or
+// property added later brings its concept along instead of leaving a semanticId
+// pointing at nothing.
+func buildConceptDescriptions(env AASEnv) []ConceptDescription {
+	wanted := map[string]bool{}
+
+	var visit func(el SubmodelElement)
+	visit = func(el SubmodelElement) {
+		if el.SemanticID != nil {
+			wanted[el.SemanticID.Keys[0].Value] = true
+		}
+		// A reference element points at a concept — that is the whole of what it
+		// does — so what it points at needs describing as much as a semanticId.
+		if ref, ok := el.Value.(*Reference); ok && len(ref.Keys) > 0 {
+			wanted[ref.Keys[0].Value] = true
+		}
+		if text, ok := el.Value.(string); ok && strings.HasPrefix(text, qudtUnit) {
+			wanted[text] = true
+		}
+		if kids, ok := el.Value.([]SubmodelElement); ok {
+			for _, kid := range kids {
+				visit(kid)
+			}
+		}
+	}
+	for _, sm := range env.Submodels {
+		if sm.SemanticID != nil {
+			wanted[sm.SemanticID.Keys[0].Value] = true
+		}
+		for _, el := range sm.SubmodelElements {
+			visit(el)
+		}
+	}
+
+	iris := make([]string, 0, len(wanted))
+	for iri := range wanted {
+		iris = append(iris, iri)
+	}
+	sort.Strings(iris)
+
+	out := []ConceptDescription{}
+	for _, iri := range iris {
+		if cd, ok := describe(iri); ok {
+			out = append(out, cd)
+		}
+	}
+	return out
+}
+
+// describe returns the concept description for one identifier, and whether this
+// bridge is the right place for it to come from.
+func describe(iri string) (ConceptDescription, bool) {
+	switch {
+	case strings.HasPrefix(iri, qudtUnit):
+		return describeUnit(iri)
+	case strings.HasPrefix(iri, qudtKind):
+		return describeQuantityKind(iri), true
+	case localConcepts[iri] != "":
+		return ConceptDescription{
+			ModelType: "ConceptDescription",
+			ID:        iri,
+			IDShort:   sanitizeIDShort(localName(iri)),
+			EmbeddedDataSpecifications: []EmbeddedDataSpecification{{
+				DataSpecification: *meaning(iec61360),
+				DataSpecificationContent: Iec61360Content{
+					ModelType:     "DataSpecificationIec61360",
+					PreferredName: en(localName(iri)),
+					DataType:      "STRING",
+					Definition:    en(localConcepts[iri]),
+				},
+			}},
+		}, true
+	default:
+		// An AFO, IDTA or Web of Things identifier: published by somebody who
+		// defines it properly, and not ours to restate.
+		return ConceptDescription{}, false
+	}
+}
+
+// describeUnit carries a unit across from QUDT into IEC 61360.
+//
+// The framework already holds the symbol and the quantity kind for every unit
+// its systems may register — it needs them to convert a reading — so this reads
+// them rather than keeping a second table that could disagree with the one the
+// conversions use. A unit the framework does not know is left undescribed:
+// inventing a symbol for it would be worse than a consumer following the IRI.
+func describeUnit(iri string) (ConceptDescription, bool) {
+	def, ok := usecases.LookupUnit(iri)
+	if !ok {
+		return ConceptDescription{}, false
+	}
+
+	content := Iec61360Content{
+		ModelType:     "DataSpecificationIec61360",
+		PreferredName: en(localName(iri)),
+		// REAL_MEASURE is what IEC 61360 calls a real number with a unit, which
+		// is what every value carrying one of these is.
+		DataType: "REAL_MEASURE",
+		UnitID:   meaning(iri),
+	}
+	// A symbol only when there is one to give. A dimensionless count has none,
+	// and an empty shortName would claim its symbol is the empty string.
+	if def.Symbol != "" {
+		content.ShortName = en(def.Symbol)
+		content.Unit = def.Symbol
+	}
+	if def.QuantityKind != "" {
+		content.Definition = en("The QUDT unit " + localName(iri) + ", which measures " +
+			localName(def.QuantityKind) + ".")
+	}
+
+	return ConceptDescription{
+		ModelType: "ConceptDescription",
+		ID:        iri,
+		IDShort:   sanitizeIDShort(localName(iri)),
+		EmbeddedDataSpecifications: []EmbeddedDataSpecification{{
+			DataSpecification:        *meaning(iec61360),
+			DataSpecificationContent: content,
+		}},
+	}, true
+}
+
+// describeQuantityKind says what a value is, as opposed to what it is counted
+// in. It carries no unit and no data type: a quantity kind is not a value, and
+// filling those fields would be describing the wrong thing.
+func describeQuantityKind(iri string) ConceptDescription {
+	name := localName(iri)
+	return ConceptDescription{
+		ModelType: "ConceptDescription",
+		ID:        iri,
+		IDShort:   sanitizeIDShort(name),
+		EmbeddedDataSpecifications: []EmbeddedDataSpecification{{
+			DataSpecification: *meaning(iec61360),
+			DataSpecificationContent: Iec61360Content{
+				ModelType:     "DataSpecificationIec61360",
+				PreferredName: en(name),
+				Definition: en("The QUDT quantity kind " + name +
+					": what the value is a measure of, independent of the unit it is given in."),
+			},
+		}},
+	}
+}

--- a/democrat/concepts_test.go
+++ b/democrat/concepts_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func twoUnits() map[string]*SystemInfo {
+	return map[string]*SystemInfo{"u": {
+		SystemURI: "u", SystemName: "thermostat", HostName: "pi", IPs: []string{"192.168.1.10"},
+		Services: []ServiceInfo{
+			{ServiceName: "controller/setpoint", ServiceDef: "setpoint",
+				URLs:         []string{"https://192.168.1.10:30185/thermostat/controller/setpoint"},
+				Unit:         "http://qudt.org/vocab/unit/DEG_C",
+				QuantityKind: "http://qudt.org/vocab/quantitykind/ThermodynamicTemperature",
+				Methods: []string{"http://www.w3.org/2011/http-methods#GET",
+					"http://www.w3.org/2011/http-methods#PUT"},
+				Subscribable: true, Form: "SignalA_v1a"},
+			{ServiceName: "controller/jitter", ServiceDef: "jitter",
+				URLs:         []string{"https://192.168.1.10:30185/thermostat/controller/jitter"},
+				Unit:         "http://qudt.org/vocab/unit/MilliSEC",
+				QuantityKind: "http://qudt.org/vocab/quantitykind/Time",
+				Form:         "SignalA_v1a"},
+		},
+	}}
+}
+
+func concepts(t *testing.T) map[string]ConceptDescription {
+	t.Helper()
+	env := buildAASEnv(twoUnits())
+	out := map[string]ConceptDescription{}
+	for _, cd := range env.ConceptDescriptions {
+		out[cd.ID] = cd
+	}
+	return out
+}
+
+// The rule: describe what only we can describe. An identifier this cloud minted
+// exists nowhere else, so if democrat does not say what it means, nobody can.
+// AFO, IDTA and Web of Things terms are published by people who define them
+// properly, and copying those definitions into every shell would be the same
+// duplication this system exists to remove — with copies that drift the first
+// time the ontology is revised.
+func TestOnlyWhatThisBridgeCanSpeakFor(t *testing.T) {
+	for id := range concepts(t) {
+		switch {
+		case strings.HasPrefix(id, alc), strings.HasPrefix(id, "http://qudt.org/"):
+			// ours to explain, or the QUDT translation only this bridge makes
+		default:
+			t.Errorf("%s is described here; it belongs to whoever published it", id)
+		}
+	}
+
+	// And specifically: the AFO predicates carried as semanticIds get none.
+	if _, described := concepts(t)[afo+"hasName"]; described {
+		t.Error("an AFO term was redefined locally instead of left to its ontology")
+	}
+}
+
+// Every identifier this cloud minted resolves inside the environment. A
+// semanticId whose concept is missing is a promise that somebody wrote down
+// what it means, broken.
+func TestNoLocalIdentifierDangles(t *testing.T) {
+	env := buildAASEnv(twoUnits())
+	described := map[string]bool{}
+	for _, cd := range env.ConceptDescriptions {
+		described[cd.ID] = true
+	}
+
+	var check func(el SubmodelElement, path string)
+	check = func(el SubmodelElement, path string) {
+		path += "/" + el.IDShort
+		if el.SemanticID != nil {
+			if id := el.SemanticID.Keys[0].Value; strings.HasPrefix(id, alc) && !described[id] {
+				t.Errorf("%s means %s, which nothing in this environment explains", path, id)
+			}
+		}
+		if kids, ok := el.Value.([]SubmodelElement); ok {
+			for _, kid := range kids {
+				check(kid, path)
+			}
+		}
+	}
+	for _, sm := range env.Submodels {
+		if id := sm.SemanticID.Keys[0].Value; strings.HasPrefix(id, alc) && !described[id] {
+			t.Errorf("submodel %s means %s, which nothing explains", sm.IDShort, id)
+		}
+		for _, el := range sm.SubmodelElements {
+			check(el, sm.IDShort)
+		}
+	}
+}
+
+// A unit's description carries the IEC 61360 translation, which is the whole
+// reason for describing a QUDT unit at all: QUDT is authoritative and
+// dereferences, but it does not publish "°C, and formally this IRI" in the shape
+// the Asset Administration Shell world reads.
+func TestAUnitCarriesItsSymbolAndItsIRI(t *testing.T) {
+	cd, ok := concepts(t)["http://qudt.org/vocab/unit/DEG_C"]
+	if !ok {
+		t.Fatal("the degree Celsius is used and not described")
+	}
+	if len(cd.EmbeddedDataSpecifications) != 1 {
+		t.Fatalf("got %d data specifications, want one", len(cd.EmbeddedDataSpecifications))
+	}
+	spec := cd.EmbeddedDataSpecifications[0]
+	if spec.DataSpecification.Keys[0].Value != iec61360 {
+		t.Errorf("content is shaped by %q, want the IEC 61360 template",
+			spec.DataSpecification.Keys[0].Value)
+	}
+	c := spec.DataSpecificationContent
+	if c.Unit != "°C" {
+		t.Errorf("unit = %q, want the symbol the framework converts with", c.Unit)
+	}
+	if c.UnitID == nil || c.UnitID.Keys[0].Value != "http://qudt.org/vocab/unit/DEG_C" {
+		t.Errorf("unitId = %v, want the QUDT IRI", c.UnitID)
+	}
+	// REAL_MEASURE is IEC 61360 for a real number with a unit. The specification
+	// requires a unit or unitId when it is used, and both are here.
+	if c.DataType != "REAL_MEASURE" {
+		t.Errorf("dataType = %q, want REAL_MEASURE", c.DataType)
+	}
+	if len(c.Definition) == 0 || !strings.Contains(c.Definition[0].Text, "ThermodynamicTemperature") {
+		t.Errorf("definition = %v, want it to say what the unit measures", c.Definition)
+	}
+	if len(c.PreferredName) == 0 || c.PreferredName[0].Language != "en" {
+		t.Error("a name in no stated language leaves a consumer to guess")
+	}
+}
+
+// The symbols come from the framework's own table — the one its conversions use
+// — rather than from a second table here that could disagree with it. A unit the
+// framework does not know is left undescribed rather than given an invented
+// symbol.
+func TestSymbolsComeFromTheTableTheConversionsUse(t *testing.T) {
+	env := buildAASEnv(map[string]*SystemInfo{"u": {
+		SystemURI: "u", SystemName: "odd",
+		Services: []ServiceInfo{{
+			ServiceName: "sensor/reading",
+			URLs:        []string{"http://127.0.0.1:20100/odd/sensor/reading"},
+			Unit:        "http://qudt.org/vocab/unit/FURLONG_PER_FORTNIGHT",
+		}},
+	}})
+	for _, cd := range env.ConceptDescriptions {
+		if strings.Contains(cd.ID, "FURLONG") {
+			t.Error("a unit the framework cannot convert was given a description anyway")
+		}
+	}
+}
+
+// A quantity kind says what a value is, not what it is counted in. Filling in a
+// unit or a data type would be describing the wrong thing.
+func TestAQuantityKindCarriesNoUnit(t *testing.T) {
+	cd, ok := concepts(t)["http://qudt.org/vocab/quantitykind/ThermodynamicTemperature"]
+	if !ok {
+		t.Fatal("the quantity kind valueSemantics points at is not described")
+	}
+	c := cd.EmbeddedDataSpecifications[0].DataSpecificationContent
+	if c.Unit != "" || c.UnitID != nil {
+		t.Errorf("a quantity kind was given a unit: %q %v", c.Unit, c.UnitID)
+	}
+	if c.DataType != "" {
+		t.Errorf("dataType = %q; a quantity kind is not a value", c.DataType)
+	}
+}
+
+// Two services measuring in the same unit produce one description of it, not
+// one each.
+func TestEachConceptIsDescribedOnce(t *testing.T) {
+	env := buildAASEnv(map[string]*SystemInfo{"u": {
+		SystemURI: "u", SystemName: "pair",
+		Services: []ServiceInfo{
+			{ServiceName: "a/temperature", URLs: []string{"http://127.0.0.1:20100/pair/a/temperature"},
+				Unit: "http://qudt.org/vocab/unit/DEG_C"},
+			{ServiceName: "b/temperature", URLs: []string{"http://127.0.0.1:20100/pair/b/temperature"},
+				Unit: "http://qudt.org/vocab/unit/DEG_C"},
+		},
+	}})
+	seen := map[string]int{}
+	for _, cd := range env.ConceptDescriptions {
+		seen[cd.ID]++
+	}
+	for id, n := range seen {
+		if n != 1 {
+			t.Errorf("%s is described %d times", id, n)
+		}
+	}
+}

--- a/democrat/go.mod
+++ b/democrat/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/democrat
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/democrat/go.sum
+++ b/democrat/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/democrat/thing.go
+++ b/democrat/thing.go
@@ -292,6 +292,15 @@ func (t *Traits) runSync() SyncResult {
 
 	env := buildAASEnv(systems)
 
+	// Concept descriptions first, so a consumer reading the store between two
+	// writes finds a semanticId that already resolves rather than one that
+	// leads nowhere for as long as this loop takes.
+	for _, cd := range env.ConceptDescriptions {
+		if err := upsertConcept(client, t.FAASTURL, cd); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("upsert concept %s: %v", cd.IDShort, err))
+		}
+	}
+
 	// Upsert shells.
 	for _, aas := range env.AssetAdministrationShells {
 		if err := upsertShell(client, t.FAASTURL, aas); err != nil {

--- a/democrat/thing_test.go
+++ b/democrat/thing_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -411,5 +412,111 @@ func TestSyncLoop_ContextCancel(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("syncLoop did not exit after context cancellation")
+	}
+}
+
+// ── semantic identifiers ──────────────────────────────────────────────────────
+
+// TestEverySubmodelAndPropertyMeansSomething is what separates a shell that can
+// be consumed from one that merely parses.
+//
+// Without a semanticId, a consumer receiving a property called
+// "ServiceUrl_temperature" can display the string and do nothing else with it:
+// nothing to look up, nothing to compare against another vendor's shell, and no
+// way to tell a URL from a serial number except by reading the name and
+// guessing. Every element carries the identifier of the concept its value came
+// from — which, since this bridge reads a knowledge graph, is the predicate the
+// literal was the object of.
+//
+// The check walks everything rather than naming elements, so an element added
+// later without a meaning fails here instead of reaching a data space.
+func TestEverySubmodelAndPropertyMeansSomething(t *testing.T) {
+	env := buildAASEnv(map[string]*SystemInfo{
+		"http://example.com/sys/thermostat": {
+			SystemURI:  "http://example.com/sys/thermostat",
+			SystemName: "thermostat",
+			HostName:   "pi-office",
+			IPs:        []string{"192.168.1.10", "127.0.0.1"},
+			Services: []ServiceInfo{
+				{ServiceName: "thermostat_temperature", ServiceDef: "temperature",
+					URL: "http://192.168.1.10:20185/thermostat/sensor1/temperature"},
+			},
+		},
+	})
+
+	if len(env.Submodels) == 0 {
+		t.Fatal("no submodels were built")
+	}
+	for _, sm := range env.Submodels {
+		if sm.SemanticID == nil {
+			t.Errorf("submodel %q says what it contains and not what it is", sm.IDShort)
+		} else if len(sm.SemanticID.Keys) != 1 || sm.SemanticID.Keys[0].Value == "" {
+			t.Errorf("submodel %q carries an empty semantic identifier", sm.IDShort)
+		} else if sm.SemanticID.Type != "ExternalReference" {
+			t.Errorf("submodel %q uses %q; a concept lives outside this shell",
+				sm.IDShort, sm.SemanticID.Type)
+		}
+
+		for _, el := range sm.SubmodelElements {
+			if el.SemanticID == nil {
+				t.Errorf("%s/%s has no meaning, so a consumer can only display it",
+					sm.IDShort, el.IDShort)
+				continue
+			}
+			iri := el.SemanticID.Keys[0].Value
+			if !strings.HasPrefix(iri, "http://") && !strings.HasPrefix(iri, "https://") {
+				t.Errorf("%s/%s means %q, which is not something anyone can look up",
+					sm.IDShort, el.IDShort, iri)
+			}
+		}
+	}
+}
+
+// The identifiers are the ontology's own, because that is where the values came
+// from. Naming an IDTA submodel template instead would claim conformance to a
+// template this does not implement, which is a worse thing to publish than a
+// local identifier that is honest about being local.
+func TestTheMeaningsComeFromTheOntologyTheValuesCameFrom(t *testing.T) {
+	env := buildAASEnv(map[string]*SystemInfo{
+		"http://example.com/sys/thermostat": {
+			SystemURI: "http://example.com/sys/thermostat", SystemName: "thermostat",
+			HostName: "pi-office", IPs: []string{"192.168.1.10"},
+			Services: []ServiceInfo{{ServiceName: "t_temperature", ServiceDef: "temperature",
+				URL: "http://192.168.1.10:20185/thermostat/sensor1/temperature"}},
+		},
+	})
+
+	want := map[string]string{
+		"SystemName":     afo + "hasName",
+		"SystemUri":      afo + "System",
+		"HostName":       afo + "hasName",
+		"IP_1":           afo + "hasIPAddress",
+		"TemperatureUrl": afo + "hasServiceDefinition",
+	}
+	found := map[string]string{}
+	for _, sm := range env.Submodels {
+		for _, el := range sm.SubmodelElements {
+			if el.SemanticID != nil {
+				found[el.IDShort] = el.SemanticID.Keys[0].Value
+			}
+		}
+	}
+	for idShort, iri := range want {
+		got, present := found[idShort]
+		if !present {
+			t.Errorf("%s is not in the shell at all", idShort)
+			continue
+		}
+		if got != iri {
+			t.Errorf("%s means %q, want %q", idShort, got, iri)
+		}
+	}
+
+	// And nothing claims to be an IDTA template, because none of these implement
+	// one yet.
+	for _, sm := range env.Submodels {
+		if strings.Contains(sm.SemanticID.Keys[0].Value, "admin-shell.io") {
+			t.Errorf("submodel %q claims an IDTA template it does not implement", sm.IDShort)
+		}
 	}
 }

--- a/democrat/thing_test.go
+++ b/democrat/thing_test.go
@@ -110,9 +110,10 @@ func TestBuildAASEnv_OneSystem(t *testing.T) {
 		t.Errorf("GlobalAssetID = %q", aas.AssetInformation.GlobalAssetID)
 	}
 
-	// Expect 3 submodels: Identity, Host, Services
-	if len(env.Submodels) != 3 {
-		t.Errorf("expected 3 submodels, got %d", len(env.Submodels))
+	// Identity, Host, Services, and the Asset Interfaces Description, which
+	// appears for any system whose services have an address.
+	if len(env.Submodels) != 4 {
+		t.Errorf("expected 4 submodels, got %d", len(env.Submodels))
 	}
 }
 
@@ -130,14 +131,14 @@ func TestBuildAASEnv_NoHost(t *testing.T) {
 
 	env := buildAASEnv(systems)
 
-	// Without host info: only Identity + Services = 2 submodels
-	if len(env.Submodels) != 2 {
-		t.Errorf("expected 2 submodels (no Host), got %d", len(env.Submodels))
+	// Without host info: Identity, Services and the interface description.
+	if len(env.Submodels) != 3 {
+		t.Errorf("expected 3 submodels (no Host), got %d", len(env.Submodels))
 	}
-	// AAS refs should also be 2 (no Host ref)
+	// And the shell references exactly the submodels that exist.
 	aas := env.AssetAdministrationShells[0]
-	if len(aas.Submodels) != 2 {
-		t.Errorf("expected 2 submodel refs, got %d", len(aas.Submodels))
+	if len(aas.Submodels) != 3 {
+		t.Errorf("expected 3 submodel refs, got %d", len(aas.Submodels))
 	}
 }
 
@@ -457,17 +458,25 @@ func TestEverySubmodelAndPropertyMeansSomething(t *testing.T) {
 				sm.IDShort, sm.SemanticID.Type)
 		}
 
-		for _, el := range sm.SubmodelElements {
+		// Recursively, because the Asset Interfaces Description nests four deep
+		// and an element buried in a collection is exactly the one that gets
+		// added later without a meaning.
+		var check func(el SubmodelElement, path string)
+		check = func(el SubmodelElement, path string) {
+			path += "/" + el.IDShort
 			if el.SemanticID == nil {
-				t.Errorf("%s/%s has no meaning, so a consumer can only display it",
-					sm.IDShort, el.IDShort)
-				continue
+				t.Errorf("%s has no meaning, so a consumer can only display it", path)
+			} else if iri := el.SemanticID.Keys[0].Value; !strings.HasPrefix(iri, "http") {
+				t.Errorf("%s means %q, which is not something anyone can look up", path, iri)
 			}
-			iri := el.SemanticID.Keys[0].Value
-			if !strings.HasPrefix(iri, "http://") && !strings.HasPrefix(iri, "https://") {
-				t.Errorf("%s/%s means %q, which is not something anyone can look up",
-					sm.IDShort, el.IDShort, iri)
+			if kids, ok := el.Value.([]SubmodelElement); ok {
+				for _, kid := range kids {
+					check(kid, path)
+				}
 			}
+		}
+		for _, el := range sm.SubmodelElements {
+			check(el, sm.IDShort)
 		}
 	}
 }
@@ -512,11 +521,21 @@ func TestTheMeaningsComeFromTheOntologyTheValuesCameFrom(t *testing.T) {
 		}
 	}
 
-	// And nothing claims to be an IDTA template, because none of these implement
-	// one yet.
+	// A submodel claims an IDTA template only when it implements one. The three
+	// local submodels describe an Arrowhead system, which no published template
+	// covers, so they are minted in the local cloud's namespace and say so. The
+	// Asset Interfaces Description does implement IDTA 02017-1-0 and carries its
+	// identifier — that is what makes it readable by tooling that has never
+	// heard of this framework.
+	local := map[string]bool{"Identity": true, "Host": true, "Services": true}
 	for _, sm := range env.Submodels {
-		if strings.Contains(sm.SemanticID.Keys[0].Value, "admin-shell.io") {
+		claimsIDTA := strings.Contains(sm.SemanticID.Keys[0].Value, "admin-shell.io")
+		switch {
+		case local[sm.IDShort] && claimsIDTA:
 			t.Errorf("submodel %q claims an IDTA template it does not implement", sm.IDShort)
+		case !local[sm.IDShort] && !claimsIDTA:
+			t.Errorf("submodel %q is not one of ours and names no published template either",
+				sm.IDShort)
 		}
 	}
 }

--- a/drafter/go.mod
+++ b/drafter/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/drafter
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/drafter/go.sum
+++ b/drafter/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/drafter/thing.go
+++ b/drafter/thing.go
@@ -214,7 +214,7 @@ func (t *Traits) sampleLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Println("sampleLoop: context cancelled, stopping")
+			log.Println("sampleLoop: context canceled, stopping")
 			return
 
 		case v := <-sigChan:

--- a/drafter/thing_test.go
+++ b/drafter/thing_test.go
@@ -192,7 +192,7 @@ func TestSampleLoop_DeliversValues(t *testing.T) {
 }
 
 // TestSampleLoop_ContextCancel verifies that sampleLoop exits cleanly when
-// the context is cancelled (it must close trayChan so callers unblock).
+// the context is canceled (it must close trayChan so callers unblock).
 func TestSampleLoop_ContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/ds18b20/ds18b20.go
+++ b/ds18b20/ds18b20.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()                                          // make sure all paths cancel the context to avoid context leak
 
 	// instantiate the System

--- a/ds18b20/go.mod
+++ b/ds18b20/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/ds18b20
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/ds18b20/go.sum
+++ b/ds18b20/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/ds18b20/thing_test.go
+++ b/ds18b20/thing_test.go
@@ -126,7 +126,7 @@ func TestParseDeviceFileSurvivesABadSensor(t *testing.T) {
 }
 
 // TestAGetDuringShutdownIsRefusedNotAPanic is the other half of the defect:
-// readTemperature closed trayChan when the context was cancelled, while the HTTP
+// readTemperature closed trayChan when the context was canceled, while the HTTP
 // handler sent on it unguarded. main cancels the context and then sleeps two
 // seconds with the servers still accepting, so any GET in that window sent on a
 // closed channel — which panics and takes the system down, on hardware in the
@@ -145,7 +145,7 @@ func TestAGetDuringShutdownIsRefusedNotAPanic(t *testing.T) {
 	select {
 	case <-stopped:
 	case <-time.After(2 * time.Second):
-		t.Fatal("readTemperature did not return after the context was cancelled")
+		t.Fatal("readTemperature did not return after the context was canceled")
 	}
 
 	// The window main leaves open: the reader has gone, the server has not.

--- a/ds18b20F/ds18b20F.go
+++ b/ds18b20F/ds18b20F.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()                                          // make sure all paths cancel the context to avoid context leak
 
 	// instantiate the System

--- a/ds18b20F/go.mod
+++ b/ds18b20F/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/ds18b20F
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/ds18b20F/go.sum
+++ b/ds18b20F/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/ds18b20F/thing_test.go
+++ b/ds18b20F/thing_test.go
@@ -126,7 +126,7 @@ func TestParseDeviceFileSurvivesABadSensor(t *testing.T) {
 }
 
 // TestAGetDuringShutdownIsRefusedNotAPanic is the other half of the defect:
-// readTemperature closed trayChan when the context was cancelled, while the HTTP
+// readTemperature closed trayChan when the context was canceled, while the HTTP
 // handler sent on it unguarded. main cancels the context and then sleeps two
 // seconds with the servers still accepting, so any GET in that window sent on a
 // closed channel — which panics and takes the system down, on hardware in the
@@ -145,7 +145,7 @@ func TestAGetDuringShutdownIsRefusedNotAPanic(t *testing.T) {
 	select {
 	case <-stopped:
 	case <-time.After(2 * time.Second):
-		t.Fatal("readTemperature did not return after the context was cancelled")
+		t.Fatal("readTemperature did not return after the context was canceled")
 	}
 
 	// The window main leaves open: the reader has gone, the server has not.

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()                                          // make sure all paths cancel the context to avoid context leak
 
 	// instantiate the System

--- a/emulator/go.mod
+++ b/emulator/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/emulator
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/emulator/go.sum
+++ b/emulator/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/emulator/thing.go
+++ b/emulator/thing.go
@@ -131,8 +131,8 @@ func (t *Traits) readSignal(w http.ResponseWriter, r *http.Request) {
 		case t.trayChan <- getMeasuremet:
 			// delivered
 		case <-r.Context().Done():
-			http.Error(w, "Request cancelled", http.StatusRequestTimeout)
-			log.Println("Signal reading request cancelled by client")
+			http.Error(w, "Request canceled", http.StatusRequestTimeout)
+			log.Println("Signal reading request canceled by client")
 			return
 		case <-time.After(1 * time.Second):
 			http.Error(w, "Asset busy", http.StatusGatewayTimeout)
@@ -152,8 +152,8 @@ func (t *Traits) readSignal(w http.ResponseWriter, r *http.Request) {
 			return
 
 		case <-r.Context().Done():
-			http.Error(w, "Request cancelled", http.StatusRequestTimeout)
-			log.Println("Signal reading request cancelled while waiting for response")
+			http.Error(w, "Request canceled", http.StatusRequestTimeout)
+			log.Println("Signal reading request canceled while waiting for response")
 			return
 
 		case <-time.After(5 * time.Second):

--- a/esr/README.md
+++ b/esr/README.md
@@ -58,7 +58,7 @@ sequenceDiagram
 
     System->>ESR: DELETE /unregister/{id}
     ESR->>Registry: delete record
-    Note over Registry: record removed<br/>expiration timer cancelled<br/>notify()
+    Note over Registry: record removed<br/>expiration timer canceled<br/>notify()
     Registry-->>ESR: success
     ESR-->>System: 200
 ```

--- a/esr/go.mod
+++ b/esr/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/esr
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/esr/go.sum
+++ b/esr/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/esr/thing.go
+++ b/esr/thing.go
@@ -140,19 +140,19 @@ func initTemplate() *components.UnitAsset {
 	registerService := components.Service{
 		Definition:  "register",
 		SubPath:     "register",
-		Details:     map[string][]string{"Forms": usecases.ServiceRegistrationFormsList()},
+		Details:     map[string][]string{"Forms": usecases.ServiceRegistrationFormsList(), "Methods": components.HTTPMethods("POST")},
 		Description: "registers a service (POST) or updates its expiration time (PUT)",
 	}
 	queryService := components.Service{
 		Definition:  "query",
 		SubPath:     "query",
-		Details:     map[string][]string{"Forms": usecases.ServQuestForms()},
+		Details:     map[string][]string{"Forms": usecases.ServQuestForms(), "Methods": components.HTTPMethods("GET", "POST")},
 		Description: "retrieves all currently available services using a GET request [accessed via a browser by a deployment technician] or retrieves a specific set of services using a POST request with a payload [initiated by the Orchestrator]",
 	}
 	unregisterService := components.Service{
 		Definition:  "unregister",
 		SubPath:     "unregister",
-		Details:     map[string][]string{"Forms": {"ID_only"}},
+		Details:     map[string][]string{"Forms": {"ID_only"}, "Methods": components.HTTPMethods("DELETE")},
 		Description: "removes a record (DELETE) based on record ID",
 	}
 	statusService := components.Service{

--- a/esr/thing_test.go
+++ b/esr/thing_test.go
@@ -71,7 +71,7 @@ func createTestSystem() components.System {
 
 func createNewSys() components.System {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()                                          // make sure all paths cancel the context to avoid context leak
 
 	// instantiate the System

--- a/ethermostat/go.mod
+++ b/ethermostat/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/ethermostat
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/ethermostat/go.sum
+++ b/ethermostat/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/ethermostat/thing.go
+++ b/ethermostat/thing.go
@@ -40,10 +40,19 @@ type Traits struct {
 	// 32-bit build stores a float64 in two words — a setpoint moving 20 to 22
 	// while the loop reads it can yield a number that was never written, and
 	// calculateOutput turns that into a fully open or fully closed valve.
-	mu        sync.RWMutex
-	SetPt     float64       `json:"setPoint"`
-	Period    time.Duration `json:"samplingPeriod"`
-	Kp        float64       `json:"kp"`
+	mu    sync.RWMutex
+	SetPt float64 `json:"setPoint"`
+	// Period is the sampling period in seconds.
+	//
+	// An int rather than a time.Duration, because a Duration holding the number
+	// 10 means ten nanoseconds and only becomes ten seconds when multiplied by
+	// time.Second — which works, and reads as if the field were already a
+	// duration. Anyone writing the obvious `Period: time.Second` for one second
+	// would get 10^9 seconds, about 31 years, and the compiler would not object.
+	// The unit belongs in the name and the conversion belongs at the point of
+	// use.
+	Period    int     `json:"samplingPeriod"`
+	Kp        float64 `json:"kp"`
 	jitter    time.Duration
 	deviation float64
 	previousT float64
@@ -155,9 +164,9 @@ func newResources(uac usecases.ConfigurableAsset, sys *components.System) ([]*co
 // ethermostat in the Makefile. A bag of configured numbers has nothing to
 // guard, so it should not be carrying the thing that does the guarding.
 type traitDefaults struct {
-	SetPt  float64       `json:"setPoint"`
-	Period time.Duration `json:"samplingPeriod"`
-	Kp     float64       `json:"kp"`
+	SetPt  float64 `json:"setPoint"`
+	Period int     `json:"samplingPeriod"`
+	Kp     float64 `json:"kp"`
 }
 
 // parseTraitDefaults extracts and validates the trait defaults from the configurable asset.
@@ -541,7 +550,7 @@ func (t *Traits) getJitter() (f forms.SignalA_v1a) {
 // period that has just begun. How often an arrival may wake it is the cervice's
 // own business, so a value reported finely does not drive an actuator finely.
 func (t *Traits) feedbackLoop(ctx context.Context) {
-	ticker := time.NewTicker(t.Period * time.Second)
+	ticker := time.NewTicker(time.Duration(t.Period) * time.Second)
 	defer ticker.Stop()
 
 	fresh := t.cervices["temperature"].Updated()

--- a/ethermostat/thing.go
+++ b/ethermostat/thing.go
@@ -481,7 +481,7 @@ func (t *Traits) getSetPoint() (f forms.SignalA_v1a) {
 	t.mu.RLock()
 	f.Value = t.SetPt
 	t.mu.RUnlock()
-	f.Unit = t.setpointUnit
+	f.Unit = usecases.UnitIRI(t.setpointUnit)
 	f.Timestamp = time.Now()
 	return f
 }
@@ -507,7 +507,7 @@ func (t *Traits) getError() (f forms.SignalA_v1a) {
 	t.mu.RLock()
 	f.Value = t.deviation
 	t.mu.RUnlock()
-	f.Unit = t.errorUnit
+	f.Unit = usecases.UnitIRI(t.errorUnit)
 	f.Timestamp = time.Now()
 	return f
 }
@@ -516,9 +516,16 @@ func (t *Traits) getError() (f forms.SignalA_v1a) {
 func (t *Traits) getJitter() (f forms.SignalA_v1a) {
 	f.NewForm()
 	t.mu.RLock()
-	f.Value = float64(t.jitter.Milliseconds())
+	// Microseconds divided out rather than Milliseconds, which truncates.
+	//
+	// This measured whole milliseconds from when every cycle made an HTTP
+	// request for its reading. A followed value is answered from cache, so the
+	// loop now runs in well under a millisecond and the service reported 0 —
+	// the metric losing its resolution to the improvement it was watching. The
+	// unit is unchanged, so nothing consuming it needs to know.
+	f.Value = float64(t.jitter.Microseconds()) / 1000
 	t.mu.RUnlock()
-	f.Unit = t.jitterUnit
+	f.Unit = usecases.UnitIRI(t.jitterUnit)
 	f.Timestamp = time.Now()
 	return f
 }

--- a/ethermostat/thing.go
+++ b/ethermostat/thing.go
@@ -66,7 +66,7 @@ func initTemplate() *components.UnitAsset {
 		Definition:  "setpoint",
 		SubPath:     "setpoint",
 		Mission:     components.MissionState,
-		Details:     map[string][]string{"Unit": {"<http://qudt.org/vocab/unit/DEG_C>"}, "QuantityKind": {"<http://qudt.org/vocab/quantitykind/ThermodynamicTemperature>"}, "Forms": {"SignalA_v1a"}},
+		Details:     map[string][]string{"Unit": {"<http://qudt.org/vocab/unit/DEG_C>"}, "QuantityKind": {"<http://qudt.org/vocab/quantitykind/ThermodynamicTemperature>"}, "Forms": {"SignalA_v1a"}, "Methods": components.HTTPMethods("GET", "PUT")},
 		RegPeriod:   120,
 		CUnit:       "Eur/h",
 		Description: "provides the current thermal setpoint (GET) or sets it (PUT)",

--- a/ethermostat/thing.go
+++ b/ethermostat/thing.go
@@ -123,7 +123,7 @@ func initTemplate() *components.UnitAsset {
 // matches each one to a temperature service from meteorologue, and returns one
 // UnitAsset per heater with its own feedback control loop.
 // If the dependent services are not yet available it retries every 15 s until they
-// are found or the system context is cancelled.
+// are found or the system context is canceled.
 func newResources(uac usecases.ConfigurableAsset, sys *components.System) ([]*components.UnitAsset, func()) {
 	defaults := parseTraitDefaults(uac)
 	sProtocols := components.SProtocols(sys.Husk.ProtoPort)

--- a/ethermostat/thing_test.go
+++ b/ethermostat/thing_test.go
@@ -34,7 +34,7 @@ func TestGetSetPoint(t *testing.T) {
 	if f.Value != 21.5 {
 		t.Errorf("expected Value 21.5, got %f", f.Value)
 	}
-	if f.Unit != "<http://qudt.org/vocab/unit/DEG_C>" {
+	if f.Unit != "http://qudt.org/vocab/unit/DEG_C" {
 		t.Errorf("expected Unit %q, got %q", "<http://qudt.org/vocab/unit/DEG_C>", f.Unit)
 	}
 }
@@ -62,7 +62,7 @@ func TestGetError(t *testing.T) {
 	if f.Value != -2.0 {
 		t.Errorf("expected Value -2.0, got %f", f.Value)
 	}
-	if f.Unit != "<http://qudt.org/vocab/unit/DEG_C>" {
+	if f.Unit != "http://qudt.org/vocab/unit/DEG_C" {
 		t.Errorf("expected Unit %q, got %q", "<http://qudt.org/vocab/unit/DEG_C>", f.Unit)
 	}
 }
@@ -74,7 +74,7 @@ func TestGetJitter(t *testing.T) {
 	if f.Value != 37.0 {
 		t.Errorf("expected Value 37.0, got %f", f.Value)
 	}
-	if f.Unit != "<http://qudt.org/vocab/unit/MilliSEC>" {
+	if f.Unit != "http://qudt.org/vocab/unit/MilliSEC" {
 		t.Errorf("expected Unit %q, got %q", "<http://qudt.org/vocab/unit/MilliSEC>", f.Unit)
 	}
 }

--- a/filmer/filmer.go
+++ b/filmer/filmer.go
@@ -31,7 +31,7 @@ import (
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()
 
 	// instantiate the System

--- a/filmer/go.mod
+++ b/filmer/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/filmer
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/filmer/go.sum
+++ b/filmer/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/flattener/go.mod
+++ b/flattener/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/flattener
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/flattener/go.sum
+++ b/flattener/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/hobbyist/go.mod
+++ b/hobbyist/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/hobbyist
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/hobbyist/go.sum
+++ b/hobbyist/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/hobbyist/hobbyist.go
+++ b/hobbyist/hobbyist.go
@@ -29,7 +29,7 @@ import (
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()                                          // make sure all paths cancel the context to avoid context leak
 
 	// instantiate the System

--- a/hobbyist/thing.go
+++ b/hobbyist/thing.go
@@ -216,7 +216,8 @@ func servicesFor(loco Locomotive) []components.Service {
 				// PERCENT told a consumer it could ask for 1000 % — which
 				// SpeedFrame then refuses. The two disagreed and the consumer
 				// was told the wrong one.
-				"Range": {"0", "100"},
+				"Range":   {"0", "100"},
+				"Methods": components.HTTPMethods("GET", "PUT"),
 			},
 			RegPeriod:   30,
 			Description: "reads the current speed (GET) or sets it (PUT), as a percentage of the decoder's full scale",
@@ -226,8 +227,7 @@ func servicesFor(loco Locomotive) []components.Service {
 			SubPath:    "direction",
 			Mission:    components.MissionActuation,
 			Details: map[string][]string{
-				"Forms": {"SignalB_v1a"},
-			},
+				"Forms": {"SignalB_v1a"}, "Methods": components.HTTPMethods("GET", "PUT")},
 			RegPeriod:   30,
 			Description: "reads the direction of travel (GET) or sets it (PUT), true being forward",
 		},
@@ -241,6 +241,7 @@ func servicesFor(loco Locomotive) []components.Service {
 			Details: map[string][]string{
 				"Forms":    {"SignalB_v1a"},
 				"Function": {fmt.Sprint(f.Number)},
+				"Methods":  components.HTTPMethods("GET", "PUT"),
 			},
 			RegPeriod:   30,
 			Description: fmt.Sprintf("switches function %d (GET reads it, PUT sets it)", f.Number),

--- a/kgrapher/go.mod
+++ b/kgrapher/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/kgrapher
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/kgrapher/go.sum
+++ b/kgrapher/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/kgrapher/kgrapher.go
+++ b/kgrapher/kgrapher.go
@@ -31,7 +31,7 @@ import (
 // This is the main function for the OPC UA Client system
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()
 
 	// instantiate the System

--- a/leveler/go.mod
+++ b/leveler/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/leveler
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/leveler/go.sum
+++ b/leveler/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/leveler/leveler.go
+++ b/leveler/leveler.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()                                          // make sure all paths cancel the context to avoid context leak
 
 	// instantiate the System

--- a/leveler/thing.go
+++ b/leveler/thing.go
@@ -41,12 +41,21 @@ type Traits struct {
 	// 32-bit build stores a float64 in two words — a setpoint moving 20 to 22
 	// while the loop reads it can yield a number that was never written, and
 	// calculateOutput turns that into a fully open or fully closed valve.
-	mu            sync.RWMutex
-	SetPt         float64       `json:"setPoint"`
-	Period        time.Duration `json:"samplingPeriod"`
-	Kp            float64       `json:"kp"`
-	Lambda        float64       `json:"lambda"`
-	Ki            float64       `json:"ki"`
+	mu    sync.RWMutex
+	SetPt float64 `json:"setPoint"`
+	// Period is the sampling period in seconds.
+	//
+	// An int rather than a time.Duration, because a Duration holding the number
+	// 10 means ten nanoseconds and only becomes ten seconds when multiplied by
+	// time.Second — which works, and reads as if the field were already a
+	// duration. Anyone writing the obvious `Period: time.Second` for one second
+	// would get 10^9 seconds, about 31 years, and the compiler would not object.
+	// The unit belongs in the name and the conversion belongs at the point of
+	// use.
+	Period        int     `json:"samplingPeriod"`
+	Kp            float64 `json:"kp"`
+	Lambda        float64 `json:"lambda"`
+	Ki            float64 `json:"ki"`
 	jitter        time.Duration
 	deviation     float64
 	integral      float64
@@ -304,7 +313,7 @@ func (t *Traits) getJitter() (f forms.SignalA_v1a) {
 // period that has just begun. How often an arrival may wake it is the cervice's
 // own business, so a value reported finely does not drive an actuator finely.
 func (t *Traits) feedbackLoop(ctx context.Context) {
-	ticker := time.NewTicker(t.Period * time.Second)
+	ticker := time.NewTicker(time.Duration(t.Period) * time.Second)
 	defer ticker.Stop()
 
 	fresh := t.cervices["level"].Updated()
@@ -374,7 +383,7 @@ func (t *Traits) processFeedbackLoop() {
 func (t *Traits) calculateOutput(levelDiff float64) float64 {
 	pTerm := t.Kp * levelDiff
 
-	sampleSeconds := (t.Period * time.Second).Seconds()
+	sampleSeconds := float64(t.Period)
 	decay := math.Exp(-sampleSeconds / t.Lambda)
 	t.integral = decay*t.integral + levelDiff*sampleSeconds
 

--- a/leveler/thing.go
+++ b/leveler/thing.go
@@ -246,7 +246,7 @@ func (t *Traits) getSetPoint() (f forms.SignalA_v1a) {
 	t.mu.RLock()
 	f.Value = t.SetPt
 	t.mu.RUnlock()
-	f.Unit = t.setpointUnit
+	f.Unit = usecases.UnitIRI(t.setpointUnit)
 	f.Timestamp = time.Now()
 	return f
 }
@@ -272,7 +272,7 @@ func (t *Traits) getError() (f forms.SignalA_v1a) {
 	t.mu.RLock()
 	f.Value = t.deviation
 	t.mu.RUnlock()
-	f.Unit = t.errorUnit
+	f.Unit = usecases.UnitIRI(t.errorUnit)
 	f.Timestamp = time.Now()
 	return f
 }
@@ -281,9 +281,16 @@ func (t *Traits) getError() (f forms.SignalA_v1a) {
 func (t *Traits) getJitter() (f forms.SignalA_v1a) {
 	f.NewForm()
 	t.mu.RLock()
-	f.Value = float64(t.jitter.Milliseconds())
+	// Microseconds divided out rather than Milliseconds, which truncates.
+	//
+	// This measured whole milliseconds from when every cycle made an HTTP
+	// request for its reading. A followed value is answered from cache, so the
+	// loop now runs in well under a millisecond and the service reported 0 —
+	// the metric losing its resolution to the improvement it was watching. The
+	// unit is unchanged, so nothing consuming it needs to know.
+	f.Value = float64(t.jitter.Microseconds()) / 1000
 	t.mu.RUnlock()
-	f.Unit = t.jitterUnit
+	f.Unit = usecases.UnitIRI(t.jitterUnit)
 	f.Timestamp = time.Now()
 	return f
 }
@@ -339,7 +346,7 @@ func (t *Traits) processFeedbackLoop() {
 	var of forms.SignalA_v1a
 	of.NewForm()
 	of.Value = output
-	of.Unit = t.cervices["pumpSpeed"].Details["Unit"][0]
+	of.Unit = usecases.UnitIRI(t.cervices["pumpSpeed"].Details["Unit"][0])
 	of.Timestamp = time.Now()
 
 	op, err := usecases.Pack(&of, "application/json")

--- a/leveler/thing.go
+++ b/leveler/thing.go
@@ -69,7 +69,7 @@ func initTemplate() *components.UnitAsset {
 		Definition:  "setpoint",
 		SubPath:     "setpoint",
 		Mission:     components.MissionState,
-		Details:     map[string][]string{"Unit": {"<http://qudt.org/vocab/unit/PERCENT>"}, "QuantityKind": {"<http://qudt.org/vocab/quantitykind/DimensionlessRatio>"}, "Forms": {"SignalA_v1a"}},
+		Details:     map[string][]string{"Unit": {"<http://qudt.org/vocab/unit/PERCENT>"}, "QuantityKind": {"<http://qudt.org/vocab/quantitykind/DimensionlessRatio>"}, "Forms": {"SignalA_v1a"}, "Methods": components.HTTPMethods("GET", "PUT")},
 		RegPeriod:   100,
 		CUnit:       "Eur/h",
 		Description: "provides the current thermal setpoint (GET) or sets it (PUT)",

--- a/leveler/thing_test.go
+++ b/leveler/thing_test.go
@@ -35,7 +35,7 @@ func TestGetSetPoint(t *testing.T) {
 	if f.Value != 42.5 {
 		t.Errorf("getSetPoint().Value = %v, want 42.5", f.Value)
 	}
-	if f.Unit != "<http://qudt.org/vocab/unit/PERCENT>" {
+	if f.Unit != "http://qudt.org/vocab/unit/PERCENT" {
 		t.Errorf("getSetPoint().Unit = %q, want %q", f.Unit, "<http://qudt.org/vocab/unit/PERCENT>")
 	}
 }
@@ -62,7 +62,7 @@ func TestGetError(t *testing.T) {
 	if f.Value != 7.3 {
 		t.Errorf("getError().Value = %v, want 7.3", f.Value)
 	}
-	if f.Unit != "<http://qudt.org/vocab/unit/PERCENT>" {
+	if f.Unit != "http://qudt.org/vocab/unit/PERCENT" {
 		t.Errorf("getError().Unit = %q, want %q", f.Unit, "<http://qudt.org/vocab/unit/PERCENT>")
 	}
 }
@@ -74,7 +74,7 @@ func TestGetJitter(t *testing.T) {
 	if f.Value != 250 {
 		t.Errorf("getJitter().Value = %v, want 250", f.Value)
 	}
-	if f.Unit != "<http://qudt.org/vocab/unit/MilliSEC>" {
+	if f.Unit != "http://qudt.org/vocab/unit/MilliSEC" {
 		t.Errorf("getJitter().Unit = %q, want %q", f.Unit, "<http://qudt.org/vocab/unit/MilliSEC>")
 	}
 }

--- a/maitreD/go.mod
+++ b/maitreD/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/maitreD
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/maitreD/go.sum
+++ b/maitreD/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/maitreD/maitreD.go
+++ b/maitreD/maitreD.go
@@ -35,7 +35,7 @@ const whitelistCachePath = "whitelist.cache.json"
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()                                          // make sure all paths cancel the context to avoid context leak
 
 	// instantiate the System

--- a/maitreD/sync.go
+++ b/maitreD/sync.go
@@ -159,7 +159,7 @@ func (t *Traits) syncOnce(ctx context.Context, client *http.Client, caURL, cache
 }
 
 // runSyncLoop bootstraps the whitelist (cache → first fetch) and then keeps
-// it fresh on a ticker until ctx is cancelled. Failure semantics, by design:
+// it fresh on a ticker until ctx is canceled. Failure semantics, by design:
 //
 //   - cache present + fetch fails → log warning, continue with cache.
 //   - cache absent + fetch fails  → return error (caller exits the process).

--- a/maitreD/thing.go
+++ b/maitreD/thing.go
@@ -92,7 +92,7 @@ func initTemplate() *components.UnitAsset {
 	attest := components.Service{
 		Definition:  "attest",
 		SubPath:     "attest",
-		Details:     map[string][]string{"Forms": {"application/json"}},
+		Details:     map[string][]string{"Forms": {"application/json"}, "Methods": components.HTTPMethods("POST")},
 		RegPeriod:   0,
 		Description: "verifies (POST) the executable hash of the requesting system against the whitelist",
 	}

--- a/meteorologue/go.mod
+++ b/meteorologue/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/meteorologue
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/meteorologue/go.sum
+++ b/meteorologue/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/meteorologue/thing.go
+++ b/meteorologue/thing.go
@@ -173,7 +173,7 @@ func (tm *TokenManager) authorizeWithBrowser() error {
 		return fmt.Errorf("timed out waiting for browser authorization (5 min)")
 	case <-ctx.Done():
 		srv.Close()
-		return fmt.Errorf("authorization cancelled")
+		return fmt.Errorf("authorization canceled")
 	}
 	srv.Close()
 
@@ -493,7 +493,7 @@ func newModuleAsset(info moduleInfo, moduleName, stationName string, sys *compon
 
 // -------------------------------------Background poller
 
-// pollNetatmo refreshes the measurement cache on every tick until the context is cancelled.
+// pollNetatmo refreshes the measurement cache on every tick until the context is canceled.
 func pollNetatmo(ctx context.Context, tm *TokenManager, cache *ModuleCache) {
 	ticker := time.NewTicker(time.Duration(tm.Period) * time.Second)
 	defer ticker.Stop()

--- a/modboss/go.mod
+++ b/modboss/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/modboss
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/modboss/go.sum
+++ b/modboss/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/modboss/modboss.go
+++ b/modboss/modboss.go
@@ -31,7 +31,7 @@ import (
 // This is the main function for the Modbus master (modboss) system
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()
 
 	// instantiate the System

--- a/modboss/thing.go
+++ b/modboss/thing.go
@@ -182,6 +182,15 @@ func newResource(configuredAsset usecases.ConfigurableAsset, sys *components.Sys
 				Traits:      t,
 			}
 			ua.ServicesMap["access"].Definition = parts[1]
+			// The register map already says whether this address may be written,
+			// so the service says so too rather than leaving a consumer to try a
+			// PUT and read the status code.
+			if methods := methodsForRights(parts[2]); len(methods) > 0 {
+				if ua.ServicesMap["access"].Details == nil {
+					ua.ServicesMap["access"].Details = map[string][]string{}
+				}
+				ua.ServicesMap["access"].Details["Methods"] = methods
+			}
 			// Capture t for the closure
 			tc := t
 			ua.ServingFunc = func(w http.ResponseWriter, r *http.Request, servicePath string) {
@@ -286,6 +295,25 @@ func missionForRights(rights string) (components.Mission, error) {
 		return components.MissionActuation, nil
 	}
 	return components.Mission{}, fmt.Errorf("unknown access mode %q: expected ro, rw or wo", rights)
+}
+
+// methodsForRights derives the HTTP methods a register's service answers from
+// its Modbus access mode, for the same reason missionForRights derives the
+// mission: the register map is where the truth already is, so neither can drift
+// from what the register actually permits.
+//
+// An unknown mode yields nothing rather than a guess; startup has already
+// refused it in missionForRights.
+func methodsForRights(rights string) []string {
+	switch strings.ToLower(strings.TrimSpace(rights)) {
+	case "ro":
+		return components.HTTPMethods("GET")
+	case "rw":
+		return components.HTTPMethods("GET", "PUT")
+	case "wo":
+		return components.HTTPMethods("PUT")
+	}
+	return nil
 }
 
 func typeOfIO(nameIO string) ioType {

--- a/modeler/go.mod
+++ b/modeler/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/modeler
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/modeler/go.sum
+++ b/modeler/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/nurse/go.mod
+++ b/nurse/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/nurse
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/nurse/go.sum
+++ b/nurse/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/nurse/nurse.go
+++ b/nurse/nurse.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()                                          // make sure all paths cancel the context to avoid context leak
 
 	// instantiate the System

--- a/nurse/thing.go
+++ b/nurse/thing.go
@@ -37,17 +37,26 @@ import (
 
 // -------------------------------------Define a measurement (or signal)
 type SignalT struct {
-	Name              string              `json:"serviceDefinition"`
-	Details           map[string][]string `json:"details"`
-	Period            time.Duration       `json:"samplingPeriod"`
-	LowerThreshold    float64             `json:"lowerThreshold"`
-	UpperThreshold    float64             `json:"upperThreshold"`
-	TOverCount        map[string]int      `json:"-"` // consecutive out-of-range count per source node
-	WorkRequested     map[string]bool     `json:"-"` // pending maintenance order per source node
-	Operational       bool                `json:"-"` // false when any node has a pending order
-	ValveTagByNode    map[string]string   `json:"-"` // node → actuator FL tag resolved from GraphDB (human-readable)
-	ValveIRIByNode    map[string]string   `json:"-"` // node → actuator FL IRI (used to link the work request in the STEP graph)
-	UnresolvableNodes map[string]bool     `json:"-"` // nodes whose actuator could not be resolved; skipped
+	Name    string              `json:"serviceDefinition"`
+	Details map[string][]string `json:"details"`
+	// Period is the sampling period in seconds.
+	//
+	// An int rather than a time.Duration, because a Duration holding the number
+	// 10 means ten nanoseconds and only becomes ten seconds when multiplied by
+	// time.Second — which works, and reads as if the field were already a
+	// duration. Anyone writing the obvious `Period: time.Second` for one second
+	// would get 10^9 seconds, about 31 years, and the compiler would not object.
+	// The unit belongs in the name and the conversion belongs at the point of
+	// use.
+	Period            int               `json:"samplingPeriod"`
+	LowerThreshold    float64           `json:"lowerThreshold"`
+	UpperThreshold    float64           `json:"upperThreshold"`
+	TOverCount        map[string]int    `json:"-"` // consecutive out-of-range count per source node
+	WorkRequested     map[string]bool   `json:"-"` // pending maintenance order per source node
+	Operational       bool              `json:"-"` // false when any node has a pending order
+	ValveTagByNode    map[string]string `json:"-"` // node → actuator FL tag resolved from GraphDB (human-readable)
+	ValveIRIByNode    map[string]string `json:"-"` // node → actuator FL IRI (used to link the work request in the STEP graph)
+	UnresolvableNodes map[string]bool   `json:"-"` // nodes whose actuator could not be resolved; skipped
 }
 
 //-------------------------------------Define the unit asset
@@ -189,7 +198,7 @@ func newResource(configuredAsset usecases.ConfigurableAsset, sys *components.Sys
 
 	// Start a monitoring goroutine for each signal.
 	for _, signal := range t.Signals {
-		go t.sigMon(signal.Name, signal.Period*time.Second)
+		go t.sigMon(signal.Name, time.Duration(signal.Period)*time.Second)
 	}
 
 	return ua, func() {

--- a/nurse/thing.go
+++ b/nurse/thing.go
@@ -69,14 +69,14 @@ func initTemplate() *components.UnitAsset {
 	monitorService := components.Service{
 		Definition:  "SignalMonitoring",
 		SubPath:     "monitor",
-		Details:     map[string][]string{},
+		Details:     map[string][]string{"Methods": components.HTTPMethods("GET", "POST")},
 		RegPeriod:   22,
 		Description: "monitors the value of the consumed service signal (GET)",
 	}
 	enrichmentService := components.Service{
 		Definition:  "EnrichmentNotification",
 		SubPath:     "enrichment",
-		Details:     map[string][]string{"Forms": {"application/json"}},
+		Details:     map[string][]string{"Forms": {"application/json"}, "Methods": components.HTTPMethods("POST")},
 		RegPeriod:   22,
 		Description: "receives planner enrichment + release notifications (POST)",
 	}

--- a/orchestrator/go.mod
+++ b/orchestrator/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/orchestrator
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/orchestrator/go.sum
+++ b/orchestrator/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/orchestrator/thing.go
+++ b/orchestrator/thing.go
@@ -56,7 +56,7 @@ func initTemplate() *components.UnitAsset {
 	squest := components.Service{
 		Definition:  "squest",
 		SubPath:     "squest",
-		Details:     map[string][]string{"DefaultForm": {"ServiceRecord_v1"}},
+		Details:     map[string][]string{"DefaultForm": {"ServiceRecord_v1"}, "Methods": components.HTTPMethods("POST")},
 		Description: "looks for the desired service described in a quest form (POST)",
 	}
 

--- a/orchestrator/thing.go
+++ b/orchestrator/thing.go
@@ -261,7 +261,7 @@ func (t *Traits) getServiceURL(newQuest forms.ServiceQuest_v1, subject string) (
 		return nil, err
 	}
 	if len(permitted.List) == 0 {
-		return nil, fmt.Errorf("%q may not use any provider of %q", subject, newQuest.ServiceDefinition)
+		return nil, refusal(subject, newQuest.ServiceDefinition)
 	}
 
 	serviceLocation := selectService(permitted)
@@ -341,7 +341,7 @@ func (t *Traits) getServicesURL(newQuest forms.ServiceQuest_v1, subject string) 
 		return nil, err
 	}
 	if len(permitted.List) == 0 {
-		return nil, fmt.Errorf("%q may not use any provider of %q", subject, newQuest.ServiceDefinition)
+		return nil, refusal(subject, newQuest.ServiceDefinition)
 	}
 
 	// Service points rather than records, because a record has nowhere to carry
@@ -367,6 +367,28 @@ func (t *Traits) noteUnidentified() {
 	t.unidentified.Do(func() {
 		log.Printf("orchestrator: service quests are arriving without a client certificate, so the consumer is unverified — an authorized cloud will refuse them\n")
 	})
+}
+
+// refusal explains to the consumer why it got nothing, in the consumer's own
+// log rather than only in the orchestrator's.
+//
+// An empty subject is not a policy decision, it is a misconfiguration, and the
+// two look identical from the consumer's end: both arrive as "may not use any
+// provider of X". The difference matters, because one is fixed by editing
+// policies.json and the other by editing the consumer's own coreSystems entry —
+// and an operator who reads "may not use" goes looking in the policy file,
+// which is the one place the answer is not.
+//
+// A quest carries a subject only when it arrives over a connection that
+// presented a client certificate, so a consumer whose orchestrator URL is http
+// can never be named by any policy however the policy is written.
+func refusal(subject, definition string) error {
+	if subject == "" {
+		return fmt.Errorf("this quest arrived without a client certificate, so no policy can name the "+
+			"consumer: reach the orchestrator over https (its coreSystems entry) rather than http, "+
+			"and no provider of %q can be granted until then", definition)
+	}
+	return fmt.Errorf("%q may not use any provider of %q", subject, definition)
 }
 
 // errNoAuthorizer says this local cloud declares no authorizer. It is a

--- a/painter/README.md
+++ b/painter/README.md
@@ -41,10 +41,10 @@ on their host; unit assets are dots within their system. Depth is suggested by
 shade and scale rather than drawn in perspective, because the point is to be
 understood quickly rather than to be impressive.
 
-**Colour is security, and only security.** A system is coloured by the posture it
+**Color is security, and only security.** A system is coloured by the posture it
 reports about itself — `authorized`, `identified`, `enrolling`, `open`. One
 system in the corner that never finished enrolling is visible from across a room.
-Because colour carries that meaning everywhere, nothing else uses it.
+Because color carries that meaning everywhere, nothing else uses it.
 
 **Lines are consumption.** A line runs from an asset that consumes a service to
 the asset that provides it, found by matching the URL the consumer was bound to
@@ -83,7 +83,7 @@ The wheel changes what is worth showing, not the magnification:
 | out   | the cloud and its hosts; lines bundled into one strand per pair |
 | →     | the systems on each host, coloured by posture |
 | →     | the unit assets within each system, and unsatisfied requests |
-| in    | services, with lines separated and labelled |
+| in    | services, with lines separated and labeled |
 
 ## Services
 

--- a/painter/go.mod
+++ b/painter/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/painter
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/painter/go.sum
+++ b/painter/go.sum
@@ -1,2 +1,4 @@
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/painter/model_test.go
+++ b/painter/model_test.go
@@ -108,7 +108,7 @@ func TestTheCloudIsDrawnFromWhatEachSystemSaysAboutItself(t *testing.T) {
 	}
 }
 
-// Colour carries the posture, so the posture has to survive the reading.
+// Color carries the posture, so the posture has to survive the reading.
 func TestEachSystemKeepsItsSecurityPosture(t *testing.T) {
 	cloud := cloudOfTwo(t)
 	levels := map[string]string{}
@@ -150,7 +150,7 @@ func TestAConsumedServiceBecomesALineBetweenTwoAssets(t *testing.T) {
 			"consumer was bound to against the URL the provider published", link.To)
 	}
 	if link.Definition != "OnOff" {
-		t.Errorf("the line is labelled %q, want OnOff", link.Definition)
+		t.Errorf("the line is labeled %q, want OnOff", link.Definition)
 	}
 	// Mission decides how the line is drawn: driving a plug must not look like
 	// reading a sensor.

--- a/painter/page.go
+++ b/painter/page.go
@@ -97,7 +97,7 @@ var centres = new Map();    // id -> where it was last drawn, so a departure kno
 
 // How long each announcement lasts. A change in a plant is worth interrupting
 // somebody for, and a picture that merely settles into a new arrangement does
-// not do that: the eye follows movement and colour, so a system arriving or
+// not do that: the eye follows movement and color, so a system arriving or
 // leaving is given both, briefly, and then the picture goes quiet again.
 var ARRIVING = 2000;
 var LEAVING = 1200;
@@ -181,10 +181,10 @@ function levelOfDetail() {
   if (view.scale < 1.6) return 0;  // the cloud, and its hosts
   if (view.scale < 3.2) return 1;  // the systems on each host
   if (view.scale < 6.5) return 2;  // the unit assets in each system
-  return 3;                        // services, labelled
+  return 3;                        // services, labeled
 }
 
-var geometry = {}; // asset id -> centre, filled while drawing, used for lines
+var geometry = {}; // asset id -> center, filled while drawing, used for lines
 var extent = 300;  // how far the picture reaches, set while drawing
 var framed = false;
 
@@ -368,7 +368,7 @@ function draw() {
                               stroke: "var(--dim)", "stroke-width": 1.4 / view.scale, fill: "none",
                               "stroke-opacity": 0.8 }, lines);
       // Mission decides the style: driving something must not look like reading
-      // it. Colour is left to say one thing only, which is security.
+      // it. Color is left to say one thing only, which is security.
       if (link.mission === "actuation" || link.mission === "control") {
         path.setAttribute("stroke-dasharray", (5 / view.scale) + " " + (3 / view.scale));
       }
@@ -436,7 +436,7 @@ function refresh() {
       // The first picture is not an arrival of everything. A page that opened
       // onto a cloud of thirty systems all flashing green would announce
       // nothing, since an announcement that fires for everything at once is
-      // just a colour.
+      // just a color.
       if (!greeted) {
         greeted = true;
         present.forEach(function (id) { seen.set(id, now - 700); });

--- a/parallax/go.mod
+++ b/parallax/go.mod
@@ -3,6 +3,6 @@ module github.com/sdoque/systems/parallax
 go 1.26.6
 
 require (
-	github.com/sdoque/mbaigo v0.1.0-alpha.9
+	github.com/sdoque/mbaigo v0.1.0-alpha.10
 	github.com/stianeikeland/go-rpio/v4 v4.6.0
 )

--- a/parallax/go.sum
+++ b/parallax/go.sum
@@ -2,5 +2,7 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
 github.com/stianeikeland/go-rpio/v4 v4.6.0 h1:eAJgtw3jTtvn/CqwbC82ntcS+dtzUTgo5qlZKe677EY=
 github.com/stianeikeland/go-rpio/v4 v4.6.0/go.mod h1:A3GvHxC1Om5zaId+HqB3HKqx4K/AqeckxB7qRjxMK7o=

--- a/parallax/parallax.go
+++ b/parallax/parallax.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()
 
 	// instantiate the System

--- a/parallax/thing.go
+++ b/parallax/thing.go
@@ -105,6 +105,7 @@ func initTemplate() *components.UnitAsset {
 			"QuantityKind": {"<http://qudt.org/vocab/quantitykind/DimensionlessRatio>"},
 			"RangeUnit":    {"<http://qudt.org/vocab/unit/DEG>"},
 			"Range":        {"0", "180"},
+			"Methods":      components.HTTPMethods("GET", "PUT"),
 		},
 		RegPeriod:   30,
 		Description: "informs of the servo's current position (GET) or updates the position (PUT)",

--- a/parallax/thing.go
+++ b/parallax/thing.go
@@ -148,7 +148,10 @@ func newResource(configuredAsset usecases.ConfigurableAsset, sys *components.Sys
 	}
 	for _, serv := range ua.ServicesMap {
 		if values := serv.Details["Unit"]; len(values) > 0 {
-			t.unit = values[0]
+			// Resolved rather than copied: an operator writes the unit
+			// Turtle-bracketed, and publishing that verbatim served the same
+			// unit under two spellings across the cloud.
+			t.unit = usecases.UnitIRI(values[0])
 			break
 		}
 	}

--- a/photographer/go.mod
+++ b/photographer/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/photographer
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/photographer/go.sum
+++ b/photographer/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/photographer/photographer.go
+++ b/photographer/photographer.go
@@ -31,7 +31,7 @@ import (
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()
 
 	// instantiate the System

--- a/recognizer/go.mod
+++ b/recognizer/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/recognizer
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/recognizer/go.sum
+++ b/recognizer/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/revolutionary/go.mod
+++ b/revolutionary/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/revolutionary
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/revolutionary/go.sum
+++ b/revolutionary/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/revolutionary/revolutionary.go
+++ b/revolutionary/revolutionary.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()                                          // make sure all paths cancel the context to avoid context leak
 
 	// instantiate the System

--- a/revolutionary/thing.go
+++ b/revolutionary/thing.go
@@ -67,7 +67,7 @@ func initTemplate() *components.UnitAsset {
 	access := components.Service{
 		Definition:  "level",
 		SubPath:     "access",
-		Details:     map[string][]string{"Forms": {"SignalA_v1a"}},
+		Details:     map[string][]string{"Forms": {"SignalA_v1a"}, "Methods": components.HTTPMethods("GET", "POST", "PUT")},
 		RegPeriod:   30,
 		Description: "reads the input (GET) or changes the output (POST) of the channel",
 	}

--- a/revolutionary/thing.go
+++ b/revolutionary/thing.go
@@ -123,7 +123,8 @@ func newResource(configuredAsset usecases.ConfigurableAsset, sys *components.Sys
 		Traits:      t,
 	}
 	if u := configuredAsset.Details["Unit"]; len(u) > 0 {
-		t.unit = u[0]
+		// The bare IRI, not the bracketed form an operator writes.
+		t.unit = usecases.UnitIRI(u[0])
 	}
 
 	ua.ServingFunc = func(w http.ResponseWriter, r *http.Request, servicePath string) {

--- a/revolutionary/thing_test.go
+++ b/revolutionary/thing_test.go
@@ -162,7 +162,7 @@ func TestConfiguredUnitIsConvertible(t *testing.T) {
 }
 
 // TestShutdownStopsTheLoopWithoutExiting is the defect this test was written
-// for: the reader goroutine called os.Exit(0) when the context was cancelled.
+// for: the reader goroutine called os.Exit(0) when the context was canceled.
 // One channel of one unit asset shutting down took the whole system with it —
 // every other asset lost its shutdown, and the cleanup function newResource
 // returns never ran. That the test binary survives this test is half the
@@ -187,7 +187,7 @@ func TestShutdownStopsTheLoopWithoutExiting(t *testing.T) {
 	select {
 	case <-stopped:
 	case <-time.After(2 * time.Second):
-		t.Fatal("sampleSignal did not return after the context was cancelled")
+		t.Fatal("sampleSignal did not return after the context was canceled")
 	}
 }
 

--- a/sailor/can_other.go
+++ b/sailor/can_other.go
@@ -36,7 +36,7 @@ func openCAN(ifname string) (int, error) {
 
 func closeCAN(_ int) {}
 
-// canPoller is a no-op stub: it blocks until the context is cancelled so the
+// canPoller is a no-op stub: it blocks until the context is canceled so the
 // goroutine started by newResource exits cleanly on shutdown.
 func canPoller(ctx context.Context, _ int, _ []pgnSubscription) {
 	<-ctx.Done()

--- a/sailor/go.mod
+++ b/sailor/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/sailor
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/sailor/go.sum
+++ b/sailor/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/sailor/thing.go
+++ b/sailor/thing.go
@@ -275,7 +275,7 @@ func (t *Traits) assetLoop(ctx context.Context) {
 			var f forms.SignalA_v1a
 			f.NewForm()
 			f.Value = t.value
-			f.Unit = t.unit
+			f.Unit = usecases.UnitIRI(t.unit)
 			f.Timestamp = t.tStamp
 			order.ValueP <- f
 		}

--- a/sapper/go.mod
+++ b/sapper/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/sapper
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/sapper/go.sum
+++ b/sapper/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/sapper/thing.go
+++ b/sapper/thing.go
@@ -247,14 +247,14 @@ func initTemplate() *components.UnitAsset {
 	ordersService := components.Service{
 		Definition:  "MaintenanceOrder",
 		SubPath:     "maintenanceorders",
-		Details:     map[string][]string{"Forms": {"application/json"}},
+		Details:     map[string][]string{"Forms": {"application/json"}, "Methods": components.HTTPMethods("GET", "POST")},
 		RegPeriod:   30,
 		Description: "creates (POST) and queries (GET ?id=<orderID>) maintenance orders",
 	}
 	firefightingService := components.Service{
 		Definition:  "firefighting",
 		SubPath:     "firefighting",
-		Details:     map[string][]string{"Forms": {"text/html"}},
+		Details:     map[string][]string{"Forms": {"text/html"}, "Methods": components.HTTPMethods("GET", "POST")},
 		RegPeriod:   30,
 		Description: "planner UI (GET) to enrich and release CRTD work orders (POST)",
 	}

--- a/telegrapher/go.mod
+++ b/telegrapher/go.mod
@@ -4,7 +4,7 @@ go 1.26.6
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.5.1
-	github.com/sdoque/mbaigo v0.1.0-alpha.9
+	github.com/sdoque/mbaigo v0.1.0-alpha.10
 )
 
 require (

--- a/telegrapher/go.sum
+++ b/telegrapher/go.sum
@@ -6,6 +6,8 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
 golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=

--- a/telegrapher/telegrapher.go
+++ b/telegrapher/telegrapher.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()
 
 	// instantiate the System

--- a/telegrapher/thing.go
+++ b/telegrapher/thing.go
@@ -150,7 +150,9 @@ func newResource(configuredAsset usecases.ConfigurableAsset, sys *components.Sys
 	}
 	for _, serv := range configuredAsset.Services {
 		if values := serv.Details["Unit"]; len(values) > 0 {
-			t.unit = values[0]
+			// Resolved rather than copied — see parallax: the configuration
+			// spelling is Turtle, the published spelling is the bare IRI.
+			t.unit = usecases.UnitIRI(values[0])
 			break
 		}
 	}

--- a/telegrapher/thing.go
+++ b/telegrapher/thing.go
@@ -87,6 +87,7 @@ func initTemplate() *components.UnitAsset {
 			"Forms":        {"SignalA_v1a"},
 			"Unit":         {"<http://qudt.org/vocab/unit/DEG_C>"},
 			"QuantityKind": {"<http://qudt.org/vocab/quantitykind/ThermodynamicTemperature>"},
+			"Methods":      components.HTTPMethods("GET", "PUT"),
 		},
 		RegPeriod:   30,
 		Description: "Read the current topic message (GET) or publish to it (PUT)",
@@ -197,7 +198,7 @@ func newResource(configuredAsset usecases.ConfigurableAsset, sys *components.Sys
 			access := components.Service{
 				Definition:  service,
 				SubPath:     "access",
-				Details:     map[string][]string{"Forms": {"mqttPayload"}},
+				Details:     map[string][]string{"Forms": {"mqttPayload"}, "Methods": components.HTTPMethods("GET", "PUT")},
 				RegPeriod:   30,
 				Description: "Read the current topic message (GET) or publish to it (PUT)",
 			}

--- a/thermostat/README.md
+++ b/thermostat/README.md
@@ -9,6 +9,95 @@ It offers three services, *setpoint*, *deviation* and *jitter*. The setpoint can
 
 The control loop is executed every 10 seconds, and can be configured.
 
+## When the loop runs: event-triggered with a periodic fallback
+
+The loop has two clocks, deliberately.
+
+```go
+select {
+case <-ticker.C:            // the guarantee that it runs at all
+        t.processFeedbackLoop()
+case <-fresh:               // the reason it runs *now*
+        t.processFeedbackLoop()
+}
+```
+
+The ticker alone is the textbook arrangement: sample every T seconds, whatever
+the world is doing. Its weakness is that a sensor plunged into warm water waits
+out the rest of the period before anything moves. The second arm removes that —
+`fresh` is `Cervice.Updated()`, closed whenever a followed value arrives — so a
+change in the process reaches the valve as soon as it is known rather than at
+the end of a period that has just begun.
+
+The ticker cannot be dropped in favour of the arrival. A provider that has died
+says nothing, and a controller waiting only for news would wait for ever,
+holding its last output while the room did as it pleased. Silence must not be
+mistaken for steadiness. So: **event-triggered, with a periodic fallback.**
+
+This is not badly-sampled periodic control; it is a recognised design. Åström
+and Bernhardsson's comparison of periodic and event-based sampling found
+event-based giving lower output variance for the same *average* sampling rate.
+The service's `Threshold` is the trigger condition and `components.DefaultWakeFloor`
+is the minimum inter-event time that keeps a noisy sensor from triggering
+without limit.
+
+### What this costs, and why it is free *here*
+
+The sampling interval is no longer constant. It ranges from the wake floor up to
+the full period — and in fact can be shorter still, because the ticker is not
+reset when an arrival wakes the loop: an update at 9.9 s runs the loop, and the
+tick at 10.0 s runs it again 100 ms later.
+
+That is free for **this** controller and only for this one.
+`calculateOutput` is `Kp·e + 50` — proportional with a bias, and no time appears
+in it. Sample it whenever you like and it returns the same answer for the same
+error.
+
+**A PID controller would not survive the same treatment unexamined.**
+
+| Term | Depends on Δt | What varying Δt does |
+|---|---|---|
+| P | no | nothing |
+| I | ∝ Δt | the effective `Ki` follows the sensor's reporting rate |
+| D | ∝ 1/Δt | a short interval amplifies the derivative without bound |
+
+The integral is the quiet one: the common implementation accumulates
+`integral += e * Ki` per *sample*, which folds the period into the tuning and is
+correct only while the period is fixed. The derivative is the dangerous one, and
+the danger is specific to event triggering: an update arrives *because* the value
+moved past its threshold, so the numerator `e[k] − e[k−1]` is largest at exactly
+the moment the denominator can be smallest.
+
+Separately, a zero-order hold contributes roughly Δt/2 of effective dead time.
+Tuning at one second and running at ten inserts about five seconds of delay into
+a loop whose phase margin assumed half a second.
+
+### If this system ever gains I and D
+
+Recorded here rather than done, because the present controller does not need it:
+
+1. **Measure Δt** from a monotonic clock every cycle and use it — multiply the
+   integral by it, divide the derivative by it. Never assume the configured
+   period; that is the assumption the second arm of the `select` invalidates.
+2. **Clamp Δt** into something like [0.2 s, 30 s], so a double wake cannot divide
+   by nothing and a stall cannot dump a large integral step in one go.
+3. **Filter the derivative** (first-order, N ≈ 8–20). Standard practice anyway;
+   mandatory once the interval varies.
+4. **Reset the ticker on an arrival**, which removes the near-zero interval
+   entirely and costs one line.
+5. **Anti-windup by back-calculation**, needed regardless because the output
+   saturates at 0 and 100 %.
+6. Or **decouple the clocks**: let the subscription keep the value fresh and run
+   the control law on a fixed tick. Δt is then uniform by construction and
+   textbook PID applies unmodified — at the price of the "acts now" property,
+   which is the whole point of the second arm. A genuine trade, not a free win.
+
+Note also that the *jitter* service measures how long a cycle took, not how long
+since the last one. For a proportional controller that is the right diagnostic.
+For PID the quantity that matters is the interval between executions, and there
+is no instrument for it yet — worth publishing Δt as its own service, and
+watching its distribution for a day, before changing the control law.
+
 ## Compiling
 To compile the code, one needs to initialize the *go.mod* file with ``` go mod init github.com/sdoque/systems/thermostat``` before running *go mod tidy*.
 

--- a/thermostat/README.md
+++ b/thermostat/README.md
@@ -29,12 +29,12 @@ out the rest of the period before anything moves. The second arm removes that �
 change in the process reaches the valve as soon as it is known rather than at
 the end of a period that has just begun.
 
-The ticker cannot be dropped in favour of the arrival. A provider that has died
+The ticker cannot be dropped in favor of the arrival. A provider that has died
 says nothing, and a controller waiting only for news would wait for ever,
 holding its last output while the room did as it pleased. Silence must not be
 mistaken for steadiness. So: **event-triggered, with a periodic fallback.**
 
-This is not badly-sampled periodic control; it is a recognised design. Åström
+This is not badly-sampled periodic control; it is a recognized design. Åström
 and Bernhardsson's comparison of periodic and event-based sampling found
 event-based giving lower output variance for the same *average* sampling rate.
 The service's `Threshold` is the trigger condition and `components.DefaultWakeFloor`

--- a/thermostat/go.mod
+++ b/thermostat/go.mod
@@ -2,4 +2,4 @@ module github.com/sdoque/systems/thermostat
 
 go 1.26.6
 
-require github.com/sdoque/mbaigo v0.1.0-alpha.9
+require github.com/sdoque/mbaigo v0.1.0-alpha.10

--- a/thermostat/go.sum
+++ b/thermostat/go.sum
@@ -2,3 +2,5 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=

--- a/thermostat/thermostat.go
+++ b/thermostat/thermostat.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()                                          // make sure all paths cancel the context to avoid context leak
 
 	// instantiate the System

--- a/thermostat/thing.go
+++ b/thermostat/thing.go
@@ -248,7 +248,7 @@ func (t *Traits) getSetPoint() (f forms.SignalA_v1a) {
 	t.mu.RLock()
 	f.Value = t.SetPt
 	t.mu.RUnlock()
-	f.Unit = t.setpointUnit
+	f.Unit = usecases.UnitIRI(t.setpointUnit)
 	f.Timestamp = time.Now()
 	return f
 }
@@ -275,7 +275,7 @@ func (t *Traits) getError() (f forms.SignalA_v1a) {
 	t.mu.RLock()
 	f.Value = t.deviation
 	t.mu.RUnlock()
-	f.Unit = t.errorUnit
+	f.Unit = usecases.UnitIRI(t.errorUnit)
 	f.Timestamp = time.Now()
 	return f
 }
@@ -284,9 +284,16 @@ func (t *Traits) getError() (f forms.SignalA_v1a) {
 func (t *Traits) getJitter() (f forms.SignalA_v1a) {
 	f.NewForm()
 	t.mu.RLock()
-	f.Value = float64(t.jitter.Milliseconds())
+	// Microseconds divided out rather than Milliseconds, which truncates.
+	//
+	// This measured whole milliseconds from when every cycle made an HTTP
+	// request for its reading. A followed value is answered from cache, so the
+	// loop now runs in well under a millisecond and the service reported 0 —
+	// the metric losing its resolution to the improvement it was watching. The
+	// unit is unchanged, so nothing consuming it needs to know.
+	f.Value = float64(t.jitter.Microseconds()) / 1000
 	t.mu.RUnlock()
-	f.Unit = t.jitterUnit
+	f.Unit = usecases.UnitIRI(t.jitterUnit)
 	f.Timestamp = time.Now()
 	return f
 }
@@ -376,7 +383,7 @@ func (t *Traits) updateValvePosition(position float64) {
 	var of forms.SignalA_v1a
 	of.NewForm()
 	of.Value = position
-	of.Unit = t.cervices["rotation"].Details["Unit"][0]
+	of.Unit = usecases.UnitIRI(t.cervices["rotation"].Details["Unit"][0])
 	of.Timestamp = time.Now()
 
 	op, err := usecases.Pack(&of, "application/json")

--- a/thermostat/thing.go
+++ b/thermostat/thing.go
@@ -67,7 +67,7 @@ func initTemplate() *components.UnitAsset {
 		Definition:  "setpoint",
 		SubPath:     "setpoint",
 		Mission:     components.MissionState,
-		Details:     map[string][]string{"Unit": {"<http://qudt.org/vocab/unit/DEG_C>"}, "QuantityKind": {"<http://qudt.org/vocab/quantitykind/ThermodynamicTemperature>"}, "Forms": {"SignalA_v1a"}},
+		Details:     map[string][]string{"Unit": {"<http://qudt.org/vocab/unit/DEG_C>"}, "QuantityKind": {"<http://qudt.org/vocab/quantitykind/ThermodynamicTemperature>"}, "Forms": {"SignalA_v1a"}, "Methods": components.HTTPMethods("GET", "PUT")},
 		RegPeriod:   120,
 		CUnit:       "Eur/h",
 		Description: "provides the current thermal setpoint (GET) or sets it (PUT)",

--- a/thermostat/thing.go
+++ b/thermostat/thing.go
@@ -40,9 +40,18 @@ type Traits struct {
 	// 32-bit build stores a float64 in two words — a setpoint moving 20 to 22
 	// while the loop reads it can yield a number that was never written, and
 	// calculateOutput turns that into a fully open or fully closed valve.
-	mu        sync.RWMutex
-	SetPt     float64             `json:"setPoint"`
-	Period    time.Duration       `json:"samplingPeriod"`
+	mu    sync.RWMutex
+	SetPt float64 `json:"setPoint"`
+	// Period is the sampling period in seconds.
+	//
+	// An int rather than a time.Duration, because a Duration holding the number
+	// 10 means ten nanoseconds and only becomes ten seconds when multiplied by
+	// time.Second — which works, and reads as if the field were already a
+	// duration. Anyone writing the obvious `Period: time.Second` for one second
+	// would get 10^9 seconds, about 31 years, and the compiler would not object.
+	// The unit belongs in the name and the conversion belongs at the point of
+	// use.
+	Period    int                 `json:"samplingPeriod"`
 	Kp        float64             `json:"kp"`
 	Lambda    float64             `json:"lambda"`
 	Ki        float64             `json:"ki"`
@@ -313,7 +322,7 @@ func (t *Traits) getJitter() (f forms.SignalA_v1a) {
 // business (components.DefaultWakeFloor): a tenth of a degree is worth
 // reporting and not worth moving a valve for.
 func (t *Traits) feedbackLoop(ctx context.Context) {
-	ticker := time.NewTicker(t.Period * time.Second)
+	ticker := time.NewTicker(time.Duration(t.Period) * time.Second)
 	defer ticker.Stop()
 
 	fresh := t.cervices["temperature"].Updated()

--- a/thermostat/thing_test.go
+++ b/thermostat/thing_test.go
@@ -416,3 +416,30 @@ func TestAConfiguredUnitIsNotOverriddenByTheTemplate(t *testing.T) {
 		t.Error("that unit resolved, so this test proves nothing")
 	}
 }
+
+// The sampling period is a count of seconds, not a duration.
+//
+// It used to be a time.Duration holding the number 10, which means ten
+// nanoseconds until something multiplies it by time.Second. That worked and
+// read as though the field were already a duration — so the obvious edit,
+// Period: time.Second for a one-second loop, would have asked for 10^9 seconds,
+// about 31 years, and compiled without complaint.
+//
+// The type now refuses that outright, which is the better guard. This holds the
+// rest: that the number means seconds, and that the default is a plausible one
+// for a control loop rather than a value someone typed in nanoseconds.
+func TestTheSamplingPeriodIsSeconds(t *testing.T) {
+	tr, ok := initTemplate().GetTraits().(*Traits)
+	if !ok {
+		t.Fatal("the template carries no traits")
+	}
+
+	got := time.Duration(tr.Period) * time.Second
+	if got < time.Second || got > time.Hour {
+		t.Errorf("the configured period is %v; a control loop is seconds, so the "+
+			"field is a count and not a duration", got)
+	}
+	if got != 10*time.Second {
+		t.Errorf("the default period is %v, want 10s", got)
+	}
+}

--- a/thermostat/thing_test.go
+++ b/thermostat/thing_test.go
@@ -38,8 +38,10 @@ func TestGetSetPoint(t *testing.T) {
 	if f.Value != 22.5 {
 		t.Errorf("expected Value 22.5, got %f", f.Value)
 	}
-	if f.Unit != "<http://qudt.org/vocab/unit/DEG_C>" {
-		t.Errorf("expected the configured unit, got %q", f.Unit)
+	// The bare IRI, not the bracketed form configuration is written in: the
+	// brackets are Turtle, and a JSON payload is not Turtle.
+	if f.Unit != "http://qudt.org/vocab/unit/DEG_C" {
+		t.Errorf("expected the configured unit unbracketed, got %q", f.Unit)
 	}
 }
 
@@ -71,8 +73,8 @@ func TestGetError(t *testing.T) {
 	if f.Value != -1.5 {
 		t.Errorf("expected Value -1.5, got %f", f.Value)
 	}
-	if f.Unit != "<http://qudt.org/vocab/unit/DEG_C>" {
-		t.Errorf("expected the setpoint's unit, got %q", f.Unit)
+	if f.Unit != "http://qudt.org/vocab/unit/DEG_C" {
+		t.Errorf("expected the setpoint's unit unbracketed, got %q", f.Unit)
 	}
 }
 
@@ -82,8 +84,8 @@ func TestGetJitter(t *testing.T) {
 	tr := &Traits{jitter: 42 * time.Millisecond, jitterUnit: "<http://qudt.org/vocab/unit/MilliSEC>"}
 	f := tr.getJitter()
 
-	if f.Unit != "<http://qudt.org/vocab/unit/MilliSEC>" {
-		t.Errorf("expected the configured unit, got %q", f.Unit)
+	if f.Unit != "http://qudt.org/vocab/unit/MilliSEC" {
+		t.Errorf("expected the configured unit unbracketed, got %q", f.Unit)
 	}
 	if f.Value != 42.0 {
 		t.Errorf("expected Value 42, got %f", f.Value)
@@ -252,11 +254,15 @@ func TestThermalErrorFollowsTheSetpointUnit(t *testing.T) {
 		if got := services["deviation"].Details["Unit"]; len(got) != 1 || got[0] != unit {
 			t.Errorf("the registered error unit is %v; want %q", got, unit)
 		}
-		if tr.getError().Unit != unit {
-			t.Errorf("the reported error unit is %q; want %q", tr.getError().Unit, unit)
+		// Registration keeps the configured spelling, which is Turtle and is
+		// what makes the unit an IRI in the knowledge graph. The published form
+		// carries the bare IRI, which is what makes two systems agree.
+		published := usecases.UnitIRI(unit)
+		if tr.getError().Unit != published {
+			t.Errorf("the reported error unit is %q; want %q", tr.getError().Unit, published)
 		}
-		if tr.getSetPoint().Unit != unit {
-			t.Errorf("the reported setpoint unit is %q; want %q", tr.getSetPoint().Unit, unit)
+		if tr.getSetPoint().Unit != published {
+			t.Errorf("the reported setpoint unit is %q; want %q", tr.getSetPoint().Unit, published)
 		}
 	}
 }

--- a/tracker/go.mod
+++ b/tracker/go.mod
@@ -3,7 +3,7 @@ module github.com/sdoque/systems/tracker
 go 1.26.6
 
 require (
-	github.com/sdoque/mbaigo v0.1.0-alpha.9
+	github.com/sdoque/mbaigo v0.1.0-alpha.10
 	modernc.org/sqlite v1.36.1
 )
 

--- a/tracker/go.sum
+++ b/tracker/go.sum
@@ -14,6 +14,8 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
 golang.org/x/exp v0.0.0-20260727155853-b88d891fe743 h1:ex206bKw+v3K0dm3andkrIF+ijyQKJG1pLgwQ2PYdQM=
 golang.org/x/exp v0.0.0-20260727155853-b88d891fe743/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=
 golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=

--- a/tracker/thing.go
+++ b/tracker/thing.go
@@ -50,7 +50,7 @@ func initTemplate() *components.UnitAsset {
 	orderService := components.Service{
 		Definition:  "order",
 		SubPath:     "order",
-		Details:     map[string][]string{"Forms": {"PenHolderOrder_v1"}},
+		Details:     map[string][]string{"Forms": {"PenHolderOrder_v1"}, "Methods": components.HTTPMethods("GET", "POST", "PUT")},
 		RegPeriod:   60,
 		Description: "create an order record (POST), update it (PUT), or retrieve it (GET ?id=N)",
 	}

--- a/uaclient/go.mod
+++ b/uaclient/go.mod
@@ -5,5 +5,5 @@ go 1.26.6
 require (
 	github.com/gopcua/opcua v0.6.5
 	github.com/pkg/errors v0.9.1
-	github.com/sdoque/mbaigo v0.1.0-alpha.9
+	github.com/sdoque/mbaigo v0.1.0-alpha.10
 )

--- a/uaclient/go.sum
+++ b/uaclient/go.sum
@@ -10,6 +10,8 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/uaclient/thing.go
+++ b/uaclient/thing.go
@@ -120,10 +120,22 @@ func missionForAccess(writable bool) components.Mission {
 // `browse` only ever enumerates the address space, so it stays measurement even
 // on a writable node — otherwise a policy granting writes to actuation would also
 // grant the enumeration of every node behind this one.
-func applyNodeMissions(services components.Services) {
+func applyNodeMissions(services components.Services, writable bool) {
 	for _, serv := range services {
 		if serv.Definition == "browse" {
 			serv.Mission = components.MissionMeasurement
+			continue
+		}
+		// The node's OPC UA access level already says whether it may be
+		// written, so the service says so too rather than leaving a consumer to
+		// try a PUT and read the status code. It is the same reasoning that
+		// derives the mission from the access level: the server is where the
+		// truth is, and a second place to state it is a second place to be
+		// wrong.
+		if writable {
+			serv.Details["Methods"] = components.HTTPMethods("GET", "PUT")
+		} else {
+			serv.Details["Methods"] = components.HTTPMethods("GET")
 		}
 	}
 }
@@ -178,7 +190,7 @@ func newResource(configuredAsset usecases.ConfigurableAsset, sys *components.Sys
 		ServicesMap: usecases.MakeServiceMap(configuredAsset.Services),
 		Traits:      rootTraits,
 	}
-	applyNodeMissions(rootUA.ServicesMap)
+	applyNodeMissions(rootUA.ServicesMap, false)
 	rootUA.ServingFunc = func(w http.ResponseWriter, r *http.Request, servicePath string) {
 		serving(rootTraits, w, r, servicePath)
 	}
@@ -222,7 +234,7 @@ func newResource(configuredAsset usecases.ConfigurableAsset, sys *components.Sys
 				ServicesMap: usecases.MakeServiceMap(configuredAsset.Services),
 				Traits:      t,
 			}
-			applyNodeMissions(newUA.ServicesMap)
+			applyNodeMissions(newUA.ServicesMap, t.Writable)
 			newUA.ServingFunc = func(w http.ResponseWriter, r *http.Request, servicePath string) {
 				serving(t, w, r, servicePath)
 			}

--- a/uaclient/thing_test.go
+++ b/uaclient/thing_test.go
@@ -134,7 +134,7 @@ func TestMissionForAccess(t *testing.T) {
 func TestApplyNodeMissionsLeavesBrowseReadOnly(t *testing.T) {
 	ua := initTemplate()
 	services := usecases.MakeServiceMap(getServicesList(*ua))
-	applyNodeMissions(services)
+	applyNodeMissions(services, true)
 
 	browseServ, ok := services["browse"]
 	if !ok {
@@ -154,6 +154,11 @@ func TestApplyNodeMissionsLeavesBrowseReadOnly(t *testing.T) {
 		t.Errorf("access mission = %q; want it to inherit the asset's", accessServ.Mission)
 	}
 
+	// And browsing is never written to, whatever the node's access level says.
+	if got := browseServ.Details["Methods"]; len(got) != 0 {
+		t.Errorf("browse declares methods %v; enumerating an address space is a read", got)
+	}
+
 	writable := &components.UnitAsset{Mission: missionForAccess(true), ServicesMap: services}
 	if got := components.EffectiveMission(writable, accessServ); got.String() != "actuation" {
 		t.Errorf("access effective mission on a writable node = %q; want %q", got, "actuation")
@@ -170,4 +175,36 @@ func getServicesList(ua components.UnitAsset) []components.Service {
 		list = append(list, *s)
 	}
 	return list
+}
+
+// A node the server reports as writable says so in its registration, and one it
+// does not report as writable says the opposite. Until this existed the only
+// record was the word "[but not yet]" in an English description, so a consumer
+// generating a client — or an AAS describing the interface — had to try a PUT
+// and read the status code to find out.
+func TestAccessDeclaresWhatTheNodeAllows(t *testing.T) {
+	const get = "<http://www.w3.org/2011/http-methods#GET>"
+	const put = "<http://www.w3.org/2011/http-methods#PUT>"
+
+	for _, tc := range []struct {
+		writable bool
+		want     []string
+	}{
+		{true, []string{get, put}},
+		{false, []string{get}},
+	} {
+		ua := initTemplate()
+		services := usecases.MakeServiceMap(getServicesList(*ua))
+		applyNodeMissions(services, tc.writable)
+
+		got := services["access"].Details["Methods"]
+		if len(got) != len(tc.want) {
+			t.Fatalf("writable=%t: got %v, want %v", tc.writable, got, tc.want)
+		}
+		for i := range tc.want {
+			if got[i] != tc.want[i] {
+				t.Errorf("writable=%t: method %d is %q, want %q", tc.writable, i, got[i], tc.want[i])
+			}
+		}
+	}
 }

--- a/uaclient/uaclient.go
+++ b/uaclient/uaclient.go
@@ -31,7 +31,7 @@ import (
 // This is the main function for the OPC UA Client system
 func main() {
 	// prepare for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background()) // create a context that can be canceled
 	defer cancel()
 
 	// instantiate the System

--- a/weatherman/go.mod
+++ b/weatherman/go.mod
@@ -3,7 +3,7 @@ module github.com/sdoque/systems/weatherman
 go 1.26.6
 
 require (
-	github.com/sdoque/mbaigo v0.1.0-alpha.9
+	github.com/sdoque/mbaigo v0.1.0-alpha.10
 	go.bug.st/serial v1.6.2
 )
 

--- a/weatherman/go.sum
+++ b/weatherman/go.sum
@@ -8,6 +8,8 @@ github.com/sdoque/mbaigo v0.1.0-alpha.8 h1:wKovBDAWMMdcJxE6kNbmtee7T3aIWa08Lkf7G
 github.com/sdoque/mbaigo v0.1.0-alpha.8/go.mod h1:sNaEleHea9b2TcroLCp+9e5cHltlo/JkT9LNag1/nmU=
 github.com/sdoque/mbaigo v0.1.0-alpha.9 h1:+Pxgw/H+Utb9Tw5pEkBHrKKDv07hPWeHUYRmYhP/mmQ=
 github.com/sdoque/mbaigo v0.1.0-alpha.9/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
+github.com/sdoque/mbaigo v0.1.0-alpha.10 h1:AqACsif+szJSJTVUXYImsuf+Pvm/324TahmPMuolB8c=
+github.com/sdoque/mbaigo v0.1.0-alpha.10/go.mod h1:uvuQ4Q1Qdi1U8BpaoBzDvst8BsskEVaVoMZ9T+5SyYc=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.bug.st/serial v1.6.2 h1:kn9LRX3sdm+WxWKufMlIRndwGfPWsH1/9lCWXQCasq8=


### PR DESCRIPTION
- semanticIds on every AAS element, then the Asset Interfaces Description, then ConceptDescriptions
- Methods declared across 21 systems, derived from configuration where it already existed
- the AlphaCloud policy file and its tests
- the bootstrap exemption documented, and the enabling procedure
- unit spelling, jitter resolution, the sampling-period type
- the thermostat's event-triggered write-up
- US spelling (separate commit, revertible on its own)